### PR TITLE
feat(desktop): allow launching in fullscreen

### DIFF
--- a/src/desktop/backends/glfw2.c
+++ b/src/desktop/backends/glfw2.c
@@ -91,6 +91,8 @@ void platformGetMousePos(double *xPos, double *yPos) {
     *yPos = (double)my;
 }
 
+static bool glfw2Fullscreen = false;
+
 static bool platformGetWindowFocus(void) {
     return glfwGetWindowParam(GLFW_ACTIVE);
 }

--- a/src/desktop/backends/glfw2.c
+++ b/src/desktop/backends/glfw2.c
@@ -18,7 +18,7 @@
 
 static Runner *g_runner;
 
-static bool tryOpenWindow(int reqW, int reqH) {
+static bool tryOpenWindow(int reqW, int reqH, bool fullscreen) {
 #ifdef GLFW_OPENGL_VERSION_MAJOR
     if (gfx == SOFTWARE || gfx == LEGACY_GL) {
         glfwOpenWindowHint(GLFW_OPENGL_VERSION_MAJOR, 1);
@@ -52,7 +52,7 @@ static bool tryOpenWindow(int reqW, int reqH) {
 
     return false;
 #else
-    return glfwOpenWindow(reqW, reqH, 8, 8, 8, 8, 24, 8, GLFW_WINDOW) != 0;
+    return glfwOpenWindow(reqW, reqH, 8, 8, 8, 8, 24, 8, fullscreen ? GLFW_FULLSCREEN : GLFW_WINDOW) != 0;
 #endif
 }
 
@@ -184,7 +184,7 @@ static void GLFWCALL scrollCallback(int pos) {
     if (g_runner) RunnerMouse_onWheel(g_runner->mouse, yoffset);
 }
 
-bool platformInit(int32_t reqW, int32_t reqH, const char *title, bool headless) {
+bool platformInit(int32_t reqW, int32_t reqH, const char *title, bool headless, bool fullscreen) {
     if (headless) {
         fprintf(stderr, "Headless mode is not supported with GLFW 2\n");
         return false;
@@ -196,7 +196,7 @@ bool platformInit(int32_t reqW, int32_t reqH, const char *title, bool headless) 
         return false;
     }
 
-    if (!tryOpenWindow(reqW, reqH)) {
+    if (!tryOpenWindow(reqW, reqH, fullscreen)) {
         fprintf(stderr, "Failed to create GLFW window\n");
         glfwTerminate();
         return false;

--- a/src/desktop/backends/glfw2.c
+++ b/src/desktop/backends/glfw2.c
@@ -29,7 +29,7 @@ static bool tryOpenWindow(int reqW, int reqH, bool fullscreen) {
     for (size_t i = 0; i < sizeof(GLCommon_versions)/sizeof(GLCommon_versions[0]); i++) {
         glfwOpenWindowHint(GLFW_OPENGL_VERSION_MAJOR, GLCommon_versions[i].major);
         glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, GLCommon_versions[i].minor);
-            
+
         if (GLCommon_versions[i].major >= 3) {
             glfwOpenWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_COMPAT_PROFILE);
             if (GLCommon_versions[i].major == 3 && GLCommon_versions[i].minor == 2) {
@@ -93,6 +93,15 @@ void platformGetMousePos(double *xPos, double *yPos) {
 
 static bool platformGetWindowFocus(void) {
     return glfwGetWindowParam(GLFW_ACTIVE);
+}
+
+bool platformGetWindowFullscreen(void) {
+    return glfw2Fullscreen;
+}
+
+void platformSetWindowFullscreen(bool fullscreen) {
+    if (fullscreen == glfw2Fullscreen) return;
+    glfw2Fullscreen = fullscreen;
 }
 
 static int32_t glfwKeyToGml(int glfwKey) {

--- a/src/desktop/backends/glfw3.c
+++ b/src/desktop/backends/glfw3.c
@@ -126,6 +126,25 @@ static bool platformGetWindowFocus(void) {
     return glfwGetWindowAttrib(window, GLFW_FOCUSED) != 0;
 }
 
+static int windowedX, windowedY, windowedW, windowedH;
+
+bool platformGetWindowFullscreen(void) {
+    return glfwGetWindowMonitor(window) != NULL;
+}
+
+void platformSetWindowFullscreen(bool fullscreen) {
+    if (fullscreen == platformGetWindowFullscreen()) return;
+    if (fullscreen) {
+        glfwGetWindowPos(window, &windowedX, &windowedY);
+        glfwGetWindowSize(window, &windowedW, &windowedH);
+        GLFWmonitor* monitor = glfwGetPrimaryMonitor();
+        const GLFWvidmode* mode = glfwGetVideoMode(monitor);
+        glfwSetWindowMonitor(window, monitor, 0, 0, mode->width, mode->height, mode->refreshRate);
+    } else {
+        glfwSetWindowMonitor(window, NULL, windowedX, windowedY, windowedW, windowedH, 0);
+    }
+}
+
 static void glfwErrorCallback(int code, const char* description) {
     fprintf(stderr, "GLFW error 0x%x: %s\n", code, description);
 }
@@ -269,11 +288,7 @@ bool platformInit(int32_t reqW, int32_t reqH, const char *title, bool headless, 
     // We set the window size AFTER the window creation so we can use glfwGetWindowContentScale
     platformSetWindowSize(reqW, reqH);
 
-    if (fullscreen) {
-        GLFWmonitor* monitor = glfwGetPrimaryMonitor();
-        const GLFWvidmode* mode = glfwGetVideoMode(monitor);
-        glfwSetWindowMonitor(window, monitor, 0, 0, mode->width, mode->height, mode->refreshRate);
-    }
+    platformSetWindowFullscreen(fullscreen);
 
     // Set up keyboard input
     glfwSetKeyCallback(window, keyCallback);

--- a/src/desktop/backends/glfw3.c
+++ b/src/desktop/backends/glfw3.c
@@ -220,7 +220,7 @@ static void scrollCallback(GLFWwindow* window, double xoffset, double yoffset) {
     RunnerMouse_onWheel(g_runner->mouse, yoffset);
 }
 
-bool platformInit(int32_t reqW, int32_t reqH, const char *title, bool headless) {
+bool platformInit(int32_t reqW, int32_t reqH, const char *title, bool headless, bool fullscreen) {
     // Init GLFW
     glfwSetErrorCallback(glfwErrorCallback);
     if (!glfwInit()) {
@@ -268,6 +268,12 @@ bool platformInit(int32_t reqW, int32_t reqH, const char *title, bool headless) 
     // If we don't do this, the window will be larger than it should be if you are using Wayland fractional scaling
     // We set the window size AFTER the window creation so we can use glfwGetWindowContentScale
     platformSetWindowSize(reqW, reqH);
+
+    if (fullscreen) {
+        GLFWmonitor* monitor = glfwGetPrimaryMonitor();
+        const GLFWvidmode* mode = glfwGetVideoMode(monitor);
+        glfwSetWindowMonitor(window, monitor, 0, 0, mode->width, mode->height, mode->refreshRate);
+    }
 
     // Set up keyboard input
     glfwSetKeyCallback(window, keyCallback);

--- a/src/desktop/backends/sdl1.c
+++ b/src/desktop/backends/sdl1.c
@@ -238,6 +238,15 @@ static bool platformGetWindowFocus(void) {
     return SDL_GetAppState() & SDL_APPINPUTFOCUS;
 }
 
+bool platformGetWindowFullscreen(void) {
+    return scr ? (scr->flags & SDL_FULLSCREEN) : false;
+}
+
+void platformSetWindowFullscreen(bool fullscreen) {
+    if (fullscreen == platformGetWindowFullscreen()) return;
+    SDL_WM_ToggleFullScreen(scr);
+}
+
 bool platformInit(int32_t reqW, int32_t reqH, const char *title, bool headless, bool fullscreen) {
     if (headless && gfx != SOFTWARE) {
         fprintf(stderr, "Headless mode on SDL 1.2 requires the software renderer!\n");
@@ -267,10 +276,7 @@ bool platformInit(int32_t reqW, int32_t reqH, const char *title, bool headless, 
     fbWidth = reqW;
     fbHeight = reqH;
     if(!headless) {
-        Uint32 videoFlags = (gfx == SOFTWARE ? 0 : SDL_OPENGL) | SDL_RESIZABLE;
-        if (fullscreen) {
-            videoFlags = (gfx == SOFTWARE ? 0 : SDL_OPENGL) | SDL_FULLSCREEN;
-        }
+        Uint32 videoFlags = (gfx == SOFTWARE ? 0 : SDL_OPENGL) | SDL_RESIZABLE | (fullscreen ? SDL_FULLSCREEN : 0);
         scr = SDL_SetVideoMode(fbWidth, fbHeight, 0, videoFlags);
         if (!scr && gfx == SOFTWARE) {
             SDL_Rect** modes = SDL_ListModes(NULL, SDL_FULLSCREEN);
@@ -420,11 +426,11 @@ static void platformResetJoysticks(void) {
             openJoysticks[i] = NULL;
         }
     }
-    
+
     SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
     SDL_InitSubSystem(SDL_INIT_JOYSTICK);
     SDL_JoystickEventState(SDL_IGNORE);
-    
+
     int numJoysticks = SDL_NumJoysticks();
     bool needsRemap = false;
     for (int i = 0; i < numJoysticks && i < MAX_GAMEPADS; i++) {
@@ -436,11 +442,11 @@ static void platformResetJoysticks(void) {
             needsRemap = true;
         }
     }
-    
+
     for (int i = numJoysticks; i < MAX_GAMEPADS; i++) {
         joystickMappings[i].valid = false;
     }
-    
+
     if (needsRemap) {
         loadGamepadMappings();
     }
@@ -506,7 +512,7 @@ bool platformHandleEvents(void) {
                         float norm = val / 32767.0f;
                         if (map->axis_button_sign[btn] < 0) norm = -norm;
                         if (norm < 0.0f) norm = 0.0f;
-                        
+
                         if (norm > slot->buttonValue[btn]) {
                             slot->buttonValue[btn] = norm;
                         }

--- a/src/desktop/backends/sdl1.c
+++ b/src/desktop/backends/sdl1.c
@@ -238,7 +238,7 @@ static bool platformGetWindowFocus(void) {
     return SDL_GetAppState() & SDL_APPINPUTFOCUS;
 }
 
-bool platformInit(int32_t reqW, int32_t reqH, const char *title, bool headless) {
+bool platformInit(int32_t reqW, int32_t reqH, const char *title, bool headless, bool fullscreen) {
     if (headless && gfx != SOFTWARE) {
         fprintf(stderr, "Headless mode on SDL 1.2 requires the software renderer!\n");
         return false;
@@ -267,7 +267,11 @@ bool platformInit(int32_t reqW, int32_t reqH, const char *title, bool headless) 
     fbWidth = reqW;
     fbHeight = reqH;
     if(!headless) {
-        scr = SDL_SetVideoMode(fbWidth, fbHeight, 0, (gfx == SOFTWARE ? 0 : SDL_OPENGL) | SDL_RESIZABLE);
+        Uint32 videoFlags = (gfx == SOFTWARE ? 0 : SDL_OPENGL) | SDL_RESIZABLE;
+        if (fullscreen) {
+            videoFlags = (gfx == SOFTWARE ? 0 : SDL_OPENGL) | SDL_FULLSCREEN;
+        }
+        scr = SDL_SetVideoMode(fbWidth, fbHeight, 0, videoFlags);
         if (!scr && gfx == SOFTWARE) {
             SDL_Rect** modes = SDL_ListModes(NULL, SDL_FULLSCREEN);
             if (modes && modes != (SDL_Rect**) -1 && modes[0]) {

--- a/src/desktop/backends/sdl2.c
+++ b/src/desktop/backends/sdl2.c
@@ -130,10 +130,9 @@ bool platformGetScaledWindowSize(int32_t* outW, int32_t* outH) {
 }
 
 static float platformGetWindowScale(void) {
-    if (!scale_x || !scale_y) return;
     int32_t draw_w, draw_h;
     int logical_w, logical_h;
-    platformGetWindowSize(&draw_w, &draw_h);
+    if (!platformGetWindowSize(&draw_w, &draw_h)) return 1.0f;
     SDL_GetWindowSize(window, &logical_w, &logical_h);
     return (logical_h > 0) ? (float)draw_h / logical_h : 1.0f;
 }
@@ -161,7 +160,7 @@ static bool platformGetWindowFocus(void) {
     return SDL_GetWindowFlags(window) & SDL_WINDOW_INPUT_FOCUS;
 }
 
-bool platformInit(int reqW, int reqH, const char *title, bool headless) {
+bool platformInit(int reqW, int reqH, const char *title, bool headless, bool fullscreen) {
     // Init SDL
     if (SDL_Init(SDL_INIT_VIDEO|SDL_INIT_TIMER|SDL_INIT_GAMECONTROLLER)) {
         fprintf(stderr, "Failed to initialize SDL\n");
@@ -213,6 +212,10 @@ bool platformInit(int reqW, int reqH, const char *title, bool headless) {
     } else {
         scr = SDL_GetWindowSurface(window);
     }
+
+    if (fullscreen)
+        SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+
     // If we don't do this, the window will be larger than it should be on HiDPI displays.
     platformSetWindowSize(reqW, reqH);
 

--- a/src/desktop/backends/sdl2.c
+++ b/src/desktop/backends/sdl2.c
@@ -160,6 +160,14 @@ static bool platformGetWindowFocus(void) {
     return SDL_GetWindowFlags(window) & SDL_WINDOW_INPUT_FOCUS;
 }
 
+bool platformGetWindowFullscreen(void) {
+    return SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN_DESKTOP;
+}
+
+void platformSetWindowFullscreen(bool fullscreen) {
+    SDL_SetWindowFullscreen(window, fullscreen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
+}
+
 bool platformInit(int reqW, int reqH, const char *title, bool headless, bool fullscreen) {
     // Init SDL
     if (SDL_Init(SDL_INIT_VIDEO|SDL_INIT_TIMER|SDL_INIT_GAMECONTROLLER)) {
@@ -213,8 +221,7 @@ bool platformInit(int reqW, int reqH, const char *title, bool headless, bool ful
         scr = SDL_GetWindowSurface(window);
     }
 
-    if (fullscreen)
-        SDL_SetWindowFullscreen(window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+    platformSetWindowFullscreen(fullscreen);
 
     // If we don't do this, the window will be larger than it should be on HiDPI displays.
     platformSetWindowSize(reqW, reqH);

--- a/src/desktop/backends/sdl3.c
+++ b/src/desktop/backends/sdl3.c
@@ -146,6 +146,14 @@ static bool platformGetWindowFocus(void) {
     return SDL_GetWindowFlags(window) & SDL_WINDOW_INPUT_FOCUS;
 }
 
+bool platformGetWindowFullscreen(void) {
+    return SDL_GetWindowFlags(window) & SDL_WINDOW_FULLSCREEN;
+}
+
+void platformSetWindowFullscreen(bool fullscreen) {
+    SDL_SetWindowFullscreen(window, fullscreen);
+}
+
 bool platformInit(int reqW, int reqH, const char *title, bool headless, bool fullscreen) {
     // Init SDL
     if (!SDL_Init(SDL_INIT_VIDEO|SDL_INIT_GAMEPAD)) {
@@ -190,8 +198,7 @@ bool platformInit(int reqW, int reqH, const char *title, bool headless, bool ful
     } else
         scr = SDL_GetWindowSurface(window);
 
-    if (fullscreen)
-        SDL_SetWindowFullscreen(window, true);
+    platformSetWindowFullscreen(fullscreen);
 
     return true;
 }

--- a/src/desktop/backends/sdl3.c
+++ b/src/desktop/backends/sdl3.c
@@ -146,7 +146,7 @@ static bool platformGetWindowFocus(void) {
     return SDL_GetWindowFlags(window) & SDL_WINDOW_INPUT_FOCUS;
 }
 
-bool platformInit(int reqW, int reqH, const char *title, bool headless) {
+bool platformInit(int reqW, int reqH, const char *title, bool headless, bool fullscreen) {
     // Init SDL
     if (!SDL_Init(SDL_INIT_VIDEO|SDL_INIT_GAMEPAD)) {
         fprintf(stderr, "Failed to initialize SDL\n");
@@ -189,6 +189,9 @@ bool platformInit(int reqW, int reqH, const char *title, bool headless) {
         SDL_GL_SetSwapInterval(0); // disable vsync
     } else
         scr = SDL_GetWindowSurface(window);
+
+    if (fullscreen)
+        SDL_SetWindowFullscreen(window, true);
 
     return true;
 }

--- a/src/desktop/main.c
+++ b/src/desktop/main.c
@@ -1424,6 +1424,8 @@ int main(int argc, char* argv[]) {
         runner->setWindowSize = platformSetWindowSize;
         runner->getWindowSize = platformGetWindowSize;
         runner->setWindowTitle = platformSetWindowTitle;
+        runner->getWindowFullscreen = platformGetWindowFullscreen;
+        runner->setWindowFullscreen = platformSetWindowFullscreen;
         Runner_setGameArgs(runner, currentGameArgs, (int32_t) arrlen(currentGameArgs));
         platformInitFunctions(runner);
 

--- a/src/desktop/main.c
+++ b/src/desktop/main.c
@@ -224,6 +224,7 @@ typedef struct {
     bool alwaysLogUnknownFunctions;
     bool alwaysLogStubbedFunctions;
     bool headless;
+    bool fullscreen;
     bool traceFrames;
     bool printRooms;
     bool printObjects;
@@ -425,6 +426,7 @@ static void printUsage(const char *argv0) {
         "    --record-inputs <file>                 - Record all keyboard inputs to a file\n"
         "    --playback-inputs <file>               - Playback input from file\n"
         "    --renderer <renderer>                  - Set the rendering API\n"
+        "    --fullscreen                           - Launch in fullscreen mode\n"
         "    --lazy-rooms                           - Lazily load rooms, increases load times but reduces memory usage\n"
         "    --eager-room <rooms>                   - When --lazy-rooms is set, keep these rooms always in memory\n"
         "    --os-type <os>                         - Set the reported OS type\n"
@@ -484,6 +486,7 @@ static void parseCommandLineArgs(CommandLineArgs* args, int argc, char* argv[]) 
         {"record-inputs", required_argument, nullptr, 'I'},
         {"playback-inputs", required_argument, nullptr, 'P'},
         {"renderer", required_argument, nullptr, 'g'},
+        {"fullscreen", no_argument, nullptr, 4101},        
         {"lazy-rooms", no_argument, nullptr, 'z'},
         {"eager-room", required_argument, nullptr, 'G'},
         {"os-type", required_argument, nullptr, 'O'},
@@ -677,6 +680,9 @@ static void parseCommandLineArgs(CommandLineArgs* args, int argc, char* argv[]) 
                 break;
             case 'g':
                 args->renderer = optarg;
+                break;
+            case 4101:
+                args->fullscreen = true;
                 break;
             case 'z':
                 args->lazyRooms = true;
@@ -1321,7 +1327,7 @@ int main(int argc, char* argv[]) {
         resolveWindowSize(&args, gen8->defaultWindowWidth, gen8->defaultWindowHeight, &windowW, &windowH);
 
         if (!platformInitialized) {
-            if (!platformInit(windowW, windowH, windowTitle, args.headless)) {
+            if (!platformInit(windowW, windowH, windowTitle, args.headless, args.fullscreen)) {
                 DataWin_free(dataWin);
                 freeCommandLineArgs(&args);
                 return 1;

--- a/src/desktop/platformdefs.h
+++ b/src/desktop/platformdefs.h
@@ -18,6 +18,8 @@ bool platformGetWindowSize(int32_t* outW, int32_t* outH);
 bool platformGetScaledWindowSize(int32_t* outW, int32_t* outH);
 void platformSetWindowSize(int32_t width, int32_t height);
 void platformSetWindowTitle(const char* title);
+bool platformGetWindowFullscreen(void);
+void platformSetWindowFullscreen(bool fullscreen);
 void platformSleepUntil(uint64_t time);
 
 enum GraphicsAPI {

--- a/src/desktop/platformdefs.h
+++ b/src/desktop/platformdefs.h
@@ -6,7 +6,7 @@
 #include "runner.h"
 #include "input_recording.h"
 
-bool platformInit(int32_t reqW, int32_t reqH, const char *title, bool headless);
+bool platformInit(int32_t reqW, int32_t reqH, const char *title, bool headless, bool fullscreen);
 void platformInitFunctions(Runner *);
 void platformExit(void);
 void platformSwapBuffers(void);

--- a/src/ps2/main.c
+++ b/src/ps2/main.c
@@ -88,16 +88,6 @@ static bool padWasStable[2] = {false, false};
 // Whether the controllers should be exposed via the GameMaker gamepad API
 static bool gamepadApiEnabled = false;
 
-// Always assume fullscreen for PS2
-static bool getWindowFullscreen() {
-    return true;
-}
-
-// No-op for PS2
-static void setWindowFullscreen(bool fullscreen) {
-    (void)fullscreen;
-}
-
 static void parsePadMappings(JsonValue* configRoot, const char* key, PadMapping** outMappings, int* outCount, const char* logLabel) {
     JsonValue* mappingsObj = JsonReader_getJsonValueByKey(configRoot, key);
     if (mappingsObj == nullptr || !JsonReader_isObject(mappingsObj)) return;
@@ -498,10 +488,6 @@ int main(int argc, char* argv[]) {
 
     PS2Overlay_drawStatusScreen(dataWin->gen8.displayName, "Creating runner...", true);
     Runner* runner = Runner_create(dataWin, vm, renderer, fileSystem, audioSystem);
-
-    // Set fullscreen stubs
-    runner->getWindowFullscreen = getWindowFullscreen;
-    runner->setWindowFullscreen = setWindowFullscreen;
 
     // Parse disabledObjects from CONFIG.JSN
     JsonValue* disabledObjectsArr = JsonReader_getJsonValueByKey(configRoot, "disabledObjects");

--- a/src/ps2/main.c
+++ b/src/ps2/main.c
@@ -88,6 +88,16 @@ static bool padWasStable[2] = {false, false};
 // Whether the controllers should be exposed via the GameMaker gamepad API
 static bool gamepadApiEnabled = false;
 
+// Always assume fullscreen for PS2
+static bool getWindowFullscreen() {
+    return true;
+}
+
+// No-op for PS2
+static void setWindowFullscreen(bool fullscreen) {
+    (void)fullscreen;
+}
+
 static void parsePadMappings(JsonValue* configRoot, const char* key, PadMapping** outMappings, int* outCount, const char* logLabel) {
     JsonValue* mappingsObj = JsonReader_getJsonValueByKey(configRoot, key);
     if (mappingsObj == nullptr || !JsonReader_isObject(mappingsObj)) return;
@@ -431,7 +441,7 @@ int main(int argc, char* argv[]) {
     options.eagerlyLoadedRooms = eagerRooms;
     options.progressCallback = PS2Overlay_statusScreenCallback;
     options.progressCallbackUserData = PS2Overlay_getCallbackData();
-    
+
     DataWin* dataWin = DataWin_parse(dataWinPath, options);
     free(dataWinPath);
     shfree(eagerRooms);
@@ -488,6 +498,10 @@ int main(int argc, char* argv[]) {
 
     PS2Overlay_drawStatusScreen(dataWin->gen8.displayName, "Creating runner...", true);
     Runner* runner = Runner_create(dataWin, vm, renderer, fileSystem, audioSystem);
+
+    // Set fullscreen stubs
+    runner->getWindowFullscreen = getWindowFullscreen;
+    runner->setWindowFullscreen = setWindowFullscreen;
 
     // Parse disabledObjects from CONFIG.JSN
     JsonValue* disabledObjectsArr = JsonReader_getJsonValueByKey(configRoot, "disabledObjects");

--- a/src/ps3/main.c
+++ b/src/ps3/main.c
@@ -80,15 +80,6 @@ const StickMapping STICK_MAPPINGS[] = {
 #define STICK_MAPPING_COUNT (sizeof(STICK_MAPPINGS) / sizeof(STICK_MAPPINGS[0]))
 static bool prevStickState[sizeof(STICK_MAPPINGS) / sizeof(STICK_MAPPINGS[0])] = {0};
 
-// ===[ FULLSCREEN STUBS ]===
-static bool getWindowFullscreen() {
-    return true;
-}
-
-static void setWindowFullscreen(bool fullscreen) {
-    (void)fullscreen;
-}
-
 // ===[ MAIN ]===
 static double freq = 0; 
 #define PS3_GET_TIME ((double)__builtin_ppc_get_timebase() / (double)freq)
@@ -301,10 +292,6 @@ int main(int argc, char* argv[]) {
     Runner* runner = Runner_create(dataWin, vm, renderer, (FileSystem*) overlayFs, audioSystem);
     runner->debugMode = false;
     //runner->osType = OS_PS3;
-
-    // Set fullscreen stubs
-    runner->getWindowFullscreen = getWindowFullscreen;
-    runner->setWindowFullscreen = setWindowFullscreen;
 
     // Initialize the first room and fire Game Start / Room Start events
     Runner_initFirstRoom(runner);

--- a/src/ps3/main.c
+++ b/src/ps3/main.c
@@ -80,6 +80,15 @@ const StickMapping STICK_MAPPINGS[] = {
 #define STICK_MAPPING_COUNT (sizeof(STICK_MAPPINGS) / sizeof(STICK_MAPPINGS[0]))
 static bool prevStickState[sizeof(STICK_MAPPINGS) / sizeof(STICK_MAPPINGS[0])] = {0};
 
+// ===[ FULLSCREEN STUBS ]===
+static bool getWindowFullscreen() {
+    return true;
+}
+
+static void setWindowFullscreen(bool fullscreen) {
+    (void)fullscreen;
+}
+
 // ===[ MAIN ]===
 static double freq = 0; 
 #define PS3_GET_TIME ((double)__builtin_ppc_get_timebase() / (double)freq)
@@ -94,7 +103,7 @@ static void sys_callback(uint64_t status, uint64_t param, void* userdata) {
         case SYSUTIL_EXIT_GAME:
             shouldExit = true;
             break;
-        
+
         case SYSUTIL_MENU_OPEN:
         case SYSUTIL_MENU_CLOSE:
             break;
@@ -292,6 +301,10 @@ int main(int argc, char* argv[]) {
     Runner* runner = Runner_create(dataWin, vm, renderer, (FileSystem*) overlayFs, audioSystem);
     runner->debugMode = false;
     //runner->osType = OS_PS3;
+
+    // Set fullscreen stubs
+    runner->getWindowFullscreen = getWindowFullscreen;
+    runner->setWindowFullscreen = setWindowFullscreen;
 
     // Initialize the first room and fire Game Start / Room Start events
     Runner_initFirstRoom(runner);

--- a/src/runner.h
+++ b/src/runner.h
@@ -503,6 +503,8 @@ struct Runner {
     bool (*getWindowSize)(int32_t* outW, int32_t* outH);
     void (*setWindowSize)(int32_t width, int32_t height);
     bool (*windowHasFocus)(void);
+    bool (*getWindowFullscreen)(void);
+    void (*setWindowFullscreen)(bool fullscreen);
     void (*setCursor)(int32_t cursorType);
     int32_t currentCursor;  // last value passed to window_set_cursor
     TileLayerMapEntry* tileLayerMap; // stb_ds hashmap: depth -> tile layer state

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -3638,7 +3638,7 @@ static RValue builtin_camera_set_view_angle(VMContext* ctx, RValue* args, int32_
     if (2 > argCount) return RValue_makeUndefined();
     Runner* runner = ctx->runner;
     GMLCamera* camera = Runner_getCameraById(runner, RValue_toInt32(args[0]));
-    if (camera != nullptr) { 
+    if (camera != nullptr) {
         camera->viewAngle = (float) RValue_toReal(args[1]);
         Runner_updateCameraViewSimple(camera);
     }
@@ -3706,7 +3706,7 @@ static RValue builtin_camera_create_view(VMContext* ctx, RValue* args, int32_t a
     if (argCount > 9) camera->borderY = (uint32_t) RValue_toInt32(args[9]);
 
     Runner_updateCameraViewSimple(camera);
-    
+
     return RValue_makeReal(id);
 }
 
@@ -7775,7 +7775,7 @@ static RValue builtin_window_get_fullscreen(VMContext* ctx, MAYBE_UNUSED RValue*
     if (runner != nullptr && runner->getWindowFullscreen != nullptr) {
         return RValue_makeBool(runner->getWindowFullscreen());
     }
-    return RValue_makeBool(false);
+    return RValue_makeBool(true);
 }
 
 static RValue builtin_window_set_fullscreen(VMContext* ctx, RValue* args, MAYBE_UNUSED int32_t argCount) {
@@ -16223,7 +16223,7 @@ static RValue builtin_sprite_get_info(VMContext* ctx, RValue* args, int32_t argC
         Instance* frame = Runner_createStruct(ctx->runner);
         int32_t idx = sprite->tpagIndices[i];
         TexturePageItem* tpagItem = &ctx->dataWin->tpag.items[idx];
-        
+
         VM_structSetAndFreeVal(ctx, frame, "w", RValue_makeReal(tpagItem->boundingWidth), -1);
         VM_structSetAndFreeVal(ctx, frame, "h", RValue_makeReal(tpagItem->boundingHeight), -1);
         VM_structSetAndFreeVal(ctx, frame, "x_offset", RValue_makeReal(tpagItem->targetX), -1);
@@ -16235,7 +16235,7 @@ static RValue builtin_sprite_get_info(VMContext* ctx, RValue* args, int32_t argC
         VM_structSetAndFreeVal(ctx, frame, "crop_width", RValue_makeReal(tpagItem->targetWidth), -1);
         VM_structSetAndFreeVal(ctx, frame, "crop_height", RValue_makeReal(tpagItem->targetHeight), -1);
         VM_structSetAndFreeVal(ctx, frame, "texture", RValue_makeReal(idx), -1);
-        
+
         *GMLArray_slot(frames, (int32_t)i) = RValue_makeStructAndIncRef(frame);
     }
     VM_structSetAndFreeVal(ctx, ret, "frames", RValue_makeArray(frames), -1);
@@ -16357,7 +16357,7 @@ void VMBuiltins_registerAll(VMContext* ctx) {
     VM_registerBuiltin(ctx, "matrix_build_projection_ortho", builtin_matrix_build_projection_ortho);
     VM_registerBuiltin(ctx, "matrix_build_projection_perspective_fov", builtin_matrix_build_projection_perspective_fov);
     VM_registerBuiltin(ctx, "matrix_get", builtin_matrix_get);
-    VM_registerBuiltin(ctx, "matrix_set", builtin_matrix_set);    
+    VM_registerBuiltin(ctx, "matrix_set", builtin_matrix_set);
     // Random
     VM_registerBuiltin(ctx, "random", builtin_random);
     VM_registerBuiltin(ctx, "random_range", builtin_random_range);

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -7770,9 +7770,25 @@ static RValue builtin_joystick_axes(VMContext* ctx, RValue* args, MAYBE_UNUSED i
     return RValue_makeReal(RunnerGamepad_getAxisCount(runner->gamepads, id));
 }
 
-// Window stubs
-STUB_RETURN_ZERO(window_get_fullscreen)
-STUB_RETURN_UNDEFINED(window_set_fullscreen)
+static RValue builtin_window_get_fullscreen(VMContext* ctx, MAYBE_UNUSED RValue* args, MAYBE_UNUSED int32_t argCount) {
+    Runner* runner = ctx->runner;
+    if (runner != nullptr && runner->getWindowFullscreen != nullptr) {
+        return RValue_makeBool(runner->getWindowFullscreen());
+    }
+    return RValue_makeBool(false);
+}
+
+static RValue builtin_window_set_fullscreen(VMContext* ctx, RValue* args, MAYBE_UNUSED int32_t argCount) {
+    if (argCount < 1) return RValue_makeUndefined();
+    Runner* runner = ctx->runner;
+    if (runner == nullptr) return RValue_makeUndefined();
+    bool fullscreen = RValue_toBool(args[0]);
+    if (runner->setWindowFullscreen != nullptr) {
+        runner->setWindowFullscreen(fullscreen);
+    }
+    return RValue_makeUndefined();
+}
+
 static RValue builtin_window_get_width(VMContext* ctx, MAYBE_UNUSED RValue* args, MAYBE_UNUSED int32_t argCount) {
     Runner* runner = ctx->runner;
     if (runner != nullptr && runner->getWindowSize != nullptr) {


### PR DESCRIPTION
Useful for linux handhelds that don't use a window manager. Tested working on SDL 1.2, SDL2, SDL3 and GLFW3

Fixes the below, pictured is Undertale (640x480) running on a TrimUI Brick Pro (1024x768) via the SDL2 desktop backend without the `--fullscreen` flag.
<img width="565" height="882" alt="image" src="https://github.com/user-attachments/assets/772d79e2-edd1-401d-9404-5eba8b7100fd" />
