### PR TITLE
fix(runner): stop events executing after exit

### DIFF
--- a/src/runner.c
+++ b/src/runner.c
@@ -371,7 +371,7 @@ static bool isEventBlockedByPendingRoom(Runner* runner, Instance* instance, int3
 
 // Executes an already-resolved event handler (see findEventCodeIdAndOwner) and verified codeId >= 0.
 static void Runner_executeResolvedEvent(Runner* runner, Instance* instance, int32_t eventType, int32_t eventSubtype, int32_t codeId, int32_t ownerObjectIndex) {
-    if (isEventBlockedByPendingRoom(runner, instance, eventType))
+    if (isEventBlockedByPendingRoom(runner, instance, eventType) || runner->shouldExit)
         return;
 
     VMContext* vm = runner->vmContext;


### PR DESCRIPTION
This stops events from executing after the runner has been signalled to exit by adding an extra check into `Runner_executeResolvedEvent`.

In one of my tests, I kept getting an extra Step log even after game_end had been called.

```
===== PATH TEST END =====
MOVE x=64 y=64 path_position=1
```

In GameMaker Runtime 2026.0.0.23, the last line did not appear.