### PR TITLE
fix(layers): Use strcasecmp instead of strcmp to resolve layers

### DIFF
--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -12964,13 +12964,13 @@ static int32_t resolveLayerIdArg(Runner* runner, RValue arg) {
         size_t runtimeLayerCount = arrlenu(runner->runtimeLayers);
         repeat(runtimeLayerCount, i) {
             RuntimeLayer* rl = &runner->runtimeLayers[i];
-            if (rl->dynamic && strcmp(rl->dynamicName, name) == 0)
+            if (rl->dynamic && rl->dynamicName != nullptr && strcasecmp(rl->dynamicName, name) == 0)
                 return (int32_t) rl->id;
         }
         if (runner->currentRoom != nullptr) {
             repeat(runner->currentRoom->layerCount, i) {
                 RoomLayer* layer = &runner->currentRoom->layers[i];
-                if (layer->name != nullptr && strcmp(layer->name, name) == 0) {
+                if (layer->name != nullptr && strcasecmp(layer->name, name) == 0) {
                     // Only resolve room-layer names that still exist in the runtime layer list.
                     if (Runner_findRuntimeLayerById(runner, (int32_t) layer->id) != nullptr)
                         return (int32_t) layer->id;

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -13030,7 +13030,7 @@ static RValue builtin_layer_get_id(VMContext* ctx, RValue* args, MAYBE_UNUSED in
     size_t runtimeLayerCount = arrlenu(runner->runtimeLayers);
     repeat(runtimeLayerCount, i) {
         RuntimeLayer* runtimeLayer = &runner->runtimeLayers[i];
-        if (runtimeLayer->dynamic && strcmp(runtimeLayer->dynamicName, name) == 0) {
+        if (runtimeLayer->dynamic && runtimeLayer->dynamicName != nullptr && strcasecmp(runtimeLayer->dynamicName, name) == 0) {
             result = (int32_t) runtimeLayer->id;
             break;
         }
@@ -13038,13 +13038,12 @@ static RValue builtin_layer_get_id(VMContext* ctx, RValue* args, MAYBE_UNUSED in
     if (result == -1 && runner->currentRoom != nullptr) {
         repeat(runner->currentRoom->layerCount, i) {
             RoomLayer* layer = &runner->currentRoom->layers[i];
-            if (layer->name != nullptr && strcmp(layer->name, name) == 0) {
+            if (layer->name != nullptr && strcasecmp(layer->name, name) == 0) {
                 result = (int32_t) layer->id;
                 break;
             }
         }
     }
-    free(name);
     return RValue_makeReal((GMLReal) result);
 }
 


### PR DESCRIPTION
In the Garden of Hopes and Dreams in Chapter 5, `layer_get_id` tries to resolve this:

```
builtin_layer_get_id: resolving layer name 'TILES_GRASS'
builtin_layer_get_id: resolving layer name 'TILES_Grass'
```

In Butterscotch, `layer_get_id` uses `strcmp`, which is case sensitive. I did the following test in GameMaker Runtime 2026.0.0.23 which shows that it should be case insensitive.

```gml
var test_layer_name = "MyTestLayer";

if (!layer_exists(test_layer_name)) {
    layer_create(0, test_layer_name);
}

var exact = layer_get_id("MyTestLayer");
var lower = layer_get_id("mytestlayer");
var upper = layer_get_id("MYTESTLAYER");

show_debug_message("Exact MyTestLayer ID: " + string(exact));
show_debug_message("Lower mytestlayer ID: " + string(lower));
show_debug_message("Upper MYTESTLAYER ID: " + string(upper));

if (exact != -1 && lower == -1 && upper == -1) {
    show_debug_message("RESULT: Layer names are case-sensitive");
}
else if (exact == lower || exact == upper) {
    show_debug_message("RESULT: Layer names are case-insensitive");
}
else {
    show_debug_message("RESULT: Unexpected behaviour");
}
```

Here was the output:

```
Exact MyTestLayer ID: ref layer 2
Lower mytestlayer ID: ref layer 2
Upper MYTESTLAYER ID: ref layer 2
RESULT: Layer names are case-insensitive
```

I've changed instances of `strcmp` to `strcasecmp` and also added a few more null checks. This fixes the crash in chapter 5.