### PR TITLE
feat(vm): add show_error function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,7 @@ if(PLATFORM STREQUAL "desktop")
     # Matches the GitHub Actions container flags (FORTIFY requires building with optimizations enabled!)
     target_compile_options(butterscotch PRIVATE "$<$<CONFIG:Release,RelWithDebInfo>:-U_FORTIFY_SOURCE;-D_FORTIFY_SOURCE=2>")
 
-    if(APPLE AND CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    if(APPLE AND NOT IOS)
         target_sources(butterscotch PRIVATE src/desktop/backends/platform/macos.m)
         find_library(COCOA_LIBRARY Cocoa REQUIRED)
         target_link_libraries(butterscotch PRIVATE ${COCOA_LIBRARY})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,12 @@ if(PLATFORM STREQUAL "desktop")
     # Matches the GitHub Actions container flags (FORTIFY requires building with optimizations enabled!)
     target_compile_options(butterscotch PRIVATE "$<$<CONFIG:Release,RelWithDebInfo>:-U_FORTIFY_SOURCE;-D_FORTIFY_SOURCE=2>")
 
+    if(APPLE)
+        target_sources(butterscotch PRIVATE src/desktop/backends/platform/macos.m)
+        find_library(COCOA_LIBRARY Cocoa REQUIRED)
+        target_link_libraries(butterscotch PRIVATE ${COCOA_LIBRARY})
+    endif()
+
     if(NOT ENABLE_LEGACY_GL AND NOT ENABLE_MODERN_GL)
         message(FATAL_ERROR "You must enable at least one renderer!")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,7 @@ if(PLATFORM STREQUAL "desktop")
     # Matches the GitHub Actions container flags (FORTIFY requires building with optimizations enabled!)
     target_compile_options(butterscotch PRIVATE "$<$<CONFIG:Release,RelWithDebInfo>:-U_FORTIFY_SOURCE;-D_FORTIFY_SOURCE=2>")
 
-    if(APPLE)
+    if(APPLE AND CMAKE_SYSTEM_NAME STREQUAL "Darwin")
         target_sources(butterscotch PRIVATE src/desktop/backends/platform/macos.m)
         find_library(COCOA_LIBRARY Cocoa REQUIRED)
         target_link_libraries(butterscotch PRIVATE ${COCOA_LIBRARY})

--- a/Makefile
+++ b/Makefile
@@ -207,8 +207,8 @@ ifndef VERBOSE
 V := @
 endif
 
-OBJS := $(addprefix build/,$(SRCS:.c=.c.$(OBJ_EXT)))
-OBJS := $(OBJS:.m=.m.$(OBJ_EXT))
+OBJS := $(addprefix build/,$(SRCS))
+OBJS := $(OBJS:%=%.$(OBJ_EXT))
 
 all: build/butterscotch
 
@@ -226,15 +226,10 @@ build/butterscotch: $(OBJS)
 	$(V)MSYS2_ARG_CONV_EXCL='*' $(_CC) $(LDFLAGS) $(OBJS) $(LIBS) $(EXTRALIBS) $(OUTPUT_EXE)$@
 	@[ -f $@.exe ] && chmod +x $@.exe || true
 
-build/%.c.$(OBJ_EXT): %.c compat/config.mk $(if $(DISABLE_MMD),$(HEADERS))
+build/%.$(OBJ_EXT): % compat/config.mk $(if $(DISABLE_MMD),$(HEADERS))
 	@mkdir -p $(dir $@)
 	@{ [ -z "$(NO_COLOR)" ] && [ -t 1 ]; } && printf " \033[1;32mCC\033[0m $<\n" || printf " CC $<\n"
 	$(V)MSYS2_ARG_CONV_EXCL='*' $(_CC) $(DEFINES) $(INCLUDES) $(CFLAGS) $(DEPFLAGS) $(COMPILE_OBJ) $(SRCFLAG)$< $(OUTPUT_OBJ)$@
-
-build/%.m.$(OBJ_EXT): %.m compat/config.mk $(if $(DISABLE_MMD),$(HEADERS))
-	@mkdir -p $(dir $@)
-	@{ [ -z "$(NO_COLOR)" ] && [ -t 1 ]; } && printf " \033[1;32mOBJC\033[0m $<\n" || printf " OBJC $<\n"
-	$(V)MSYS2_ARG_CONV_EXCL='*' $(_CC) $(DEFINES) $(INCLUDES) $(CFLAGS) $(DEPFLAGS) $(COMPILE_OBJ) $< $(OUTPUT_OBJ)$@
 
 clean:
 	rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,9 @@ PKG_CONFIG_FLAGS := --static
 endif
 INCLUDES += $(INCLUDE)src/desktop
 ifeq ($(DESKTOP_BACKEND),glfw3)
-GLFW3_LIBS += $(shell $(PKG_CONFIG) $(PKG_CONFIG_FLAGS) --libs glfw3)
+GLFW3_CFLAGS := $(shell $(PKG_CONFIG) $(PKG_CONFIG_FLAGS) --cflags glfw3)
+GLFW3_LIBS := $(shell $(PKG_CONFIG) $(PKG_CONFIG_FLAGS) --libs glfw3)
+CFLAGS += $(GLFW3_CFLAGS)
 LIBS += $(GLFW3_LIBS)
 DEFINES += $(DEFINE)USE_GLFW3
 ENABLE_GLAD := 1
@@ -206,6 +208,7 @@ V := @
 endif
 
 OBJS := $(addprefix build/,$(SRCS:.c=.c.$(OBJ_EXT)))
+OBJS := $(OBJS:.m=.m.$(OBJ_EXT))
 
 all: build/butterscotch
 
@@ -227,6 +230,11 @@ build/%.c.$(OBJ_EXT): %.c compat/config.mk $(if $(DISABLE_MMD),$(HEADERS))
 	@mkdir -p $(dir $@)
 	@{ [ -z "$(NO_COLOR)" ] && [ -t 1 ]; } && printf " \033[1;32mCC\033[0m $<\n" || printf " CC $<\n"
 	$(V)MSYS2_ARG_CONV_EXCL='*' $(_CC) $(DEFINES) $(INCLUDES) $(CFLAGS) $(DEPFLAGS) $(COMPILE_OBJ) $(SRCFLAG)$< $(OUTPUT_OBJ)$@
+
+build/%.m.$(OBJ_EXT): %.m compat/config.mk $(if $(DISABLE_MMD),$(HEADERS))
+	@mkdir -p $(dir $@)
+	@{ [ -z "$(NO_COLOR)" ] && [ -t 1 ]; } && printf " \033[1;32mOBJC\033[0m $<\n" || printf " OBJC $<\n"
+	$(V)MSYS2_ARG_CONV_EXCL='*' $(_CC) $(DEFINES) $(INCLUDES) $(CFLAGS) $(DEPFLAGS) $(COMPILE_OBJ) $< $(OUTPUT_OBJ)$@
 
 clean:
 	rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -80,17 +80,29 @@ GLFW3_LIBS += $(shell $(PKG_CONFIG) $(PKG_CONFIG_FLAGS) --libs glfw3)
 LIBS += $(GLFW3_LIBS)
 DEFINES += $(DEFINE)USE_GLFW3
 ENABLE_GLAD := 1
+ifeq ($(OS),Darwin)
+SRCS += src/desktop/backends/platform/macos.m
+LIBS += -framework Cocoa
+endif
 endif
 ifeq ($(DESKTOP_BACKEND),glfw2)
 GLFW2_LIBS += $(shell $(PKG_CONFIG) $(PKG_CONFIG_FLAGS) --libs libglfw)
 LIBS += $(GLFW2_LIBS)
 DEFINES += $(DEFINE)USE_GLFW2
 ENABLE_GLAD := 1
+ifeq ($(OS),Darwin)
+SRCS += src/desktop/backends/platform/macos.m
+LIBS += -framework Cocoa
+endif
 endif
 ifeq ($(DESKTOP_BACKEND),sdl1)
 SDL1_LIBS += $(shell $(PKG_CONFIG) $(PKG_CONFIG_FLAGS) --libs sdl)
 LIBS += $(SDL1_LIBS)
 DEFINES += $(DEFINE)USE_SDL1
+ifeq ($(OS),Darwin)
+SRCS += src/desktop/backends/platform/macos.m
+LIBS += -framework Cocoa
+endif
 endif
 ifeq ($(DESKTOP_BACKEND),sdl2)
 SDL2_LIBS += $(shell $(PKG_CONFIG) $(PKG_CONFIG_FLAGS) --libs sdl2)

--- a/src/desktop/backends/glfw2.c
+++ b/src/desktop/backends/glfw2.c
@@ -66,7 +66,7 @@ void platformShowErrorDialogue(const char* message) {
 #elif defined(TARGET_OS_MAC)
     show_error_box(message);
 #else
-    void(message); // Suppress unused parameter warning
+    (void)message; // Suppress unused parameter warning
 #endif
 }
 

--- a/src/desktop/backends/glfw2.c
+++ b/src/desktop/backends/glfw2.c
@@ -56,6 +56,18 @@ static bool tryOpenWindow(int reqW, int reqH) {
 #endif
 }
 
+#ifdef TARGET_OS_MAC
+void show_error_box(const char *message);
+#endif
+
+void platformShowErrorDialogue(const char* message) {
+#ifdef _WIN32
+    MessageBoxA(NULL, message, "Error", MB_OK | MB_ICONERROR);
+#elif defined(TARGET_OS_MAC)
+    show_error_box(message);
+#endif
+}
+
 void platformSetWindowTitle(const char* title) {
     char windowTitle[256];
     snprintf(windowTitle, sizeof(windowTitle), "Butterscotch - %s", title);

--- a/src/desktop/backends/glfw2.c
+++ b/src/desktop/backends/glfw2.c
@@ -65,6 +65,8 @@ void platformShowErrorDialogue(const char* message) {
     MessageBoxA(NULL, message, "Error", MB_OK | MB_ICONERROR);
 #elif defined(TARGET_OS_MAC)
     show_error_box(message);
+#else
+    void(message); // Suppress unused parameter warning
 #endif
 }
 

--- a/src/desktop/backends/glfw3.c
+++ b/src/desktop/backends/glfw3.c
@@ -79,6 +79,18 @@ static GLFWwindow *tryOpenWindow(int reqW, int reqH, const char* title) {
     return NULL;
 }
 
+#ifdef TARGET_OS_MAC
+void show_error_box(const char *message);
+#endif
+
+void platformShowErrorDialogue(const char* message) {
+#ifdef _WIN32
+    MessageBoxA(NULL, message, "Error", MB_OK | MB_ICONERROR);
+#elif defined(TARGET_OS_MAC)
+    show_error_box(message);
+#endif
+}
+
 void platformSetWindowTitle(const char* title) {
     char windowTitle[256];
     snprintf(windowTitle, sizeof(windowTitle), "Butterscotch - %s", title);

--- a/src/desktop/backends/glfw3.c
+++ b/src/desktop/backends/glfw3.c
@@ -88,6 +88,8 @@ void platformShowErrorDialogue(const char* message) {
     MessageBoxA(NULL, message, "Error", MB_OK | MB_ICONERROR);
 #elif defined(TARGET_OS_MAC)
     show_error_box(message);
+#else
+    void(message); // Suppress unused parameter warning
 #endif
 }
 

--- a/src/desktop/backends/glfw3.c
+++ b/src/desktop/backends/glfw3.c
@@ -89,7 +89,7 @@ void platformShowErrorDialogue(const char* message) {
 #elif defined(TARGET_OS_MAC)
     show_error_box(message);
 #else
-    void(message); // Suppress unused parameter warning
+    (void)message; // Suppress unused parameter warning
 #endif
 }
 

--- a/src/desktop/backends/platform/macos.m
+++ b/src/desktop/backends/platform/macos.m
@@ -1,10 +1,9 @@
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1030
-#import <Cocoa/Cocoa.h>
-#else
+#include <AvailabilityMacros.h>
 #import <AppKit/AppKit.h>
-#endif
 
-void show_error_box(const char *message)
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1030
+
+static void show_error_box_nsalert(const char *message)
 {
 #if __has_feature(objc_arc)
     @autoreleasepool {
@@ -12,36 +11,21 @@ void show_error_box(const char *message)
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 #endif
 
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1030
+    NSAlert *alert = [[NSAlert alloc] init];
 
-        NSAlert *alert = [[NSAlert alloc] init];
-
-        [alert setMessageText:@"Error"];
-        [alert setInformativeText:[NSString stringWithUTF8String:message]];
-        [alert addButtonWithTitle:@"OK"];
-
+    [alert setMessageText:@"Error"];
+    [alert setInformativeText:[NSString stringWithUTF8String:message]];
+    [alert addButtonWithTitle:@"OK"];
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 101200
         [alert setAlertStyle:NSAlertStyleCritical];
 #else
         [alert setAlertStyle:NSCriticalAlertStyle];
 #endif
 
-        [alert runModal];
+    [alert runModal];
 
 #if !__has_feature(objc_arc)
-        [alert release];
-#endif
-
-#else
-
-        NSRunAlertPanel(
-            @"Error",
-            [NSString stringWithUTF8String:message],
-            @"OK",
-            nil,
-            nil
-        );
-
+    [alert release];
 #endif
 
 #if !__has_feature(objc_arc)
@@ -50,5 +34,33 @@ void show_error_box(const char *message)
 
 #if __has_feature(objc_arc)
     }
+#endif
+}
+
+#else
+
+static void show_error_box_nsrunalertpanel(const char *message)
+{
+    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+
+    NSRunAlertPanel(
+        @"Error",
+        [NSString stringWithUTF8String:message],
+        @"OK",
+        nil,
+        nil
+    );
+
+    [pool drain];
+}
+
+#endif
+
+void show_error_box(const char *message)
+{
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1030
+    show_error_box_nsalert(message);
+#else
+    show_error_box_nsrunalertpanel(message);
 #endif
 }

--- a/src/desktop/backends/platform/macos.m
+++ b/src/desktop/backends/platform/macos.m
@@ -1,5 +1,5 @@
 #include <AvailabilityMacros.h>
-#import <AppKit/AppKit.h>
+#include <AppKit/AppKit.h>
 
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 1030
 

--- a/src/desktop/backends/platform/macos.m
+++ b/src/desktop/backends/platform/macos.m
@@ -1,44 +1,25 @@
 #include <AvailabilityMacros.h>
 #include <AppKit/AppKit.h>
 
-#ifndef __has_feature
-#define __has_feature(x) 0
-#endif
-
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1030
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1030 // NSAlert is available in 10.3 and later
 
 static void show_error_box_nsalert(const char *message)
 {
-#if __has_feature(objc_arc)
-    @autoreleasepool {
-#else
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-#endif
-
     NSAlert *alert = [[NSAlert alloc] init];
 
     [alert setMessageText:@"Error"];
     [alert setInformativeText:[NSString stringWithUTF8String:message]];
     [alert addButtonWithTitle:@"OK"];
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101200
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101200 // NSAlertStyleCritical is available in 10.12 and later
         [alert setAlertStyle:NSAlertStyleCritical];
 #else
         [alert setAlertStyle:NSCriticalAlertStyle];
 #endif
 
     [alert runModal];
-
-#if !__has_feature(objc_arc)
     [alert release];
-#endif
-
-#if !__has_feature(objc_arc)
     [pool drain];
-#endif
-
-#if __has_feature(objc_arc)
-    }
-#endif
 }
 
 #else

--- a/src/desktop/backends/platform/macos.m
+++ b/src/desktop/backends/platform/macos.m
@@ -1,4 +1,8 @@
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1030
 #import <Cocoa/Cocoa.h>
+#else
+#import <AppKit/AppKit.h>
+#endif
 
 void show_error_box(const char *message)
 {
@@ -7,6 +11,8 @@ void show_error_box(const char *message)
 #else
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 #endif
+
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1030
 
         NSAlert *alert = [[NSAlert alloc] init];
 
@@ -26,9 +32,23 @@ void show_error_box(const char *message)
         [alert release];
 #endif
 
+#else
+
+        NSRunAlertPanel(
+            @"Error",
+            [NSString stringWithUTF8String:message],
+            @"OK",
+            nil,
+            nil
+        );
+
+#endif
+
+#if !__has_feature(objc_arc)
+    [pool drain];
+#endif
+
 #if __has_feature(objc_arc)
     }
-#else
-    [pool drain];
 #endif
 }

--- a/src/desktop/backends/platform/macos.m
+++ b/src/desktop/backends/platform/macos.m
@@ -2,16 +2,33 @@
 
 void show_error_box(const char *message)
 {
+#if __has_feature(objc_arc)
     @autoreleasepool {
+#else
+    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+#endif
+
         NSAlert *alert = [[NSAlert alloc] init];
 
         [alert setMessageText:@"Error"];
-        [alert setInformativeText:
-            [NSString stringWithUTF8String:message]];
-
+        [alert setInformativeText:[NSString stringWithUTF8String:message]];
         [alert addButtonWithTitle:@"OK"];
+
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101200
         [alert setAlertStyle:NSAlertStyleCritical];
+#else
+        [alert setAlertStyle:NSCriticalAlertStyle];
+#endif
 
         [alert runModal];
+
+#if !__has_feature(objc_arc)
+        [alert release];
+#endif
+
+#if __has_feature(objc_arc)
     }
+#else
+    [pool drain];
+#endif
 }

--- a/src/desktop/backends/platform/macos.m
+++ b/src/desktop/backends/platform/macos.m
@@ -1,0 +1,18 @@
+#import <Cocoa/Cocoa.h>
+
+void show_error_box(const char *message)
+{
+    printf("Error: %s\n", message);
+    @autoreleasepool {
+        NSAlert *alert = [[NSAlert alloc] init];
+
+        [alert setMessageText:@"Error"];
+        [alert setInformativeText:
+            [NSString stringWithUTF8String:message]];
+
+        [alert addButtonWithTitle:@"OK"];
+        [alert setAlertStyle:NSAlertStyleCritical];
+
+        [alert runModal];
+    }
+}

--- a/src/desktop/backends/platform/macos.m
+++ b/src/desktop/backends/platform/macos.m
@@ -1,6 +1,10 @@
 #include <AvailabilityMacros.h>
 #include <AppKit/AppKit.h>
 
+#ifndef __has_feature
+#define __has_feature(x) 0
+#endif
+
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= 1030
 
 static void show_error_box_nsalert(const char *message)

--- a/src/desktop/backends/platform/macos.m
+++ b/src/desktop/backends/platform/macos.m
@@ -2,7 +2,6 @@
 
 void show_error_box(const char *message)
 {
-    printf("Error: %s\n", message);
     @autoreleasepool {
         NSAlert *alert = [[NSAlert alloc] init];
 

--- a/src/desktop/backends/platform/macos.m
+++ b/src/desktop/backends/platform/macos.m
@@ -1,11 +1,12 @@
 #include <AvailabilityMacros.h>
 #include <AppKit/AppKit.h>
 
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1030 // NSAlert is available in 10.3 and later
-
-static void show_error_box_nsalert(const char *message)
+static void show_error_box(const char *message)
 {
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1030 // NSAlert is available in 10.3 and later
+
     NSAlert *alert = [[NSAlert alloc] init];
 
     [alert setMessageText:@"Error"];
@@ -19,14 +20,8 @@ static void show_error_box_nsalert(const char *message)
 
     [alert runModal];
     [alert release];
-    [pool drain];
-}
 
 #else
-
-static void show_error_box_nsrunalertpanel(const char *message)
-{
-    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 
     NSRunAlertPanel(
         @"Error",
@@ -36,16 +31,7 @@ static void show_error_box_nsrunalertpanel(const char *message)
         nil
     );
 
+#endif
+
     [pool drain];
-}
-
-#endif
-
-void show_error_box(const char *message)
-{
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1030
-    show_error_box_nsalert(message);
-#else
-    show_error_box_nsrunalertpanel(message);
-#endif
 }

--- a/src/desktop/backends/sdl1.c
+++ b/src/desktop/backends/sdl1.c
@@ -215,6 +215,8 @@ void platformShowErrorDialogue(const char* message) {
     MessageBoxA(NULL, message, "Error", MB_OK | MB_ICONERROR);
 #elif defined(TARGET_OS_MAC)
     show_error_box(message);
+#else
+    void(message); // Suppress unused parameter warning
 #endif
 }
 

--- a/src/desktop/backends/sdl1.c
+++ b/src/desktop/backends/sdl1.c
@@ -216,7 +216,7 @@ void platformShowErrorDialogue(const char* message) {
 #elif defined(TARGET_OS_MAC)
     show_error_box(message);
 #else
-    void(message); // Suppress unused parameter warning
+    (void)message; // Suppress unused parameter warning
 #endif
 }
 

--- a/src/desktop/backends/sdl1.c
+++ b/src/desktop/backends/sdl1.c
@@ -4,6 +4,10 @@
 #include <ctype.h>
 #include <stdlib.h>
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 #include <SDL/SDL.h>
 
 #include "common.h"
@@ -201,6 +205,19 @@ static void loadGamepadMappings(void) {
     }
     fclose(f);
 }
+
+#ifdef TARGET_OS_MAC
+void show_error_box(const char *message);
+#endif
+
+void platformShowErrorDialogue(const char* message) {
+#ifdef _WIN32
+    MessageBoxA(NULL, message, "Error", MB_OK | MB_ICONERROR);
+#elif defined(TARGET_OS_MAC)
+    show_error_box(message);
+#endif
+}
+
 void platformSetWindowTitle(const char* title) {
     char windowTitle[256];
     snprintf(windowTitle, sizeof(windowTitle), "Butterscotch - %s", title);

--- a/src/desktop/backends/sdl2.c
+++ b/src/desktop/backends/sdl2.c
@@ -91,6 +91,15 @@ static SDL_Window *tryOpenWindow(int reqW, int reqH, const char* title, Uint32 f
     return NULL;
 }
 
+void platformShowErrorDialogue(const char* message) {
+    SDL_ShowSimpleMessageBox(
+        SDL_MESSAGEBOX_ERROR,
+        "Error",
+        message,
+        NULL
+    );
+}
+
 void platformSetWindowTitle(const char* title) {
     char windowTitle[256];
     snprintf(windowTitle, sizeof(windowTitle), "Butterscotch - %s", title);

--- a/src/desktop/backends/sdl3.c
+++ b/src/desktop/backends/sdl3.c
@@ -108,6 +108,15 @@ static SDL_Window *tryOpenWindow(int reqW, int reqH, const char* title, Uint32 f
     return NULL;
 }
 
+void platformShowErrorDialogue(const char* message) {
+    SDL_ShowSimpleMessageBox(
+        SDL_MESSAGEBOX_ERROR,
+        "Error",
+        message,
+        NULL
+    );
+}
+
 void platformSetWindowTitle(const char* title) {
     char windowTitle[256];
     snprintf(windowTitle, sizeof(windowTitle), "Butterscotch - %s", title);

--- a/src/desktop/main.c
+++ b/src/desktop/main.c
@@ -1420,6 +1420,7 @@ int main(int argc, char* argv[]) {
         runner->setWindowSize = platformSetWindowSize;
         runner->getWindowSize = platformGetWindowSize;
         runner->setWindowTitle = platformSetWindowTitle;
+        runner->showErrorDialogue = platformShowErrorDialogue;
         Runner_setGameArgs(runner, currentGameArgs, (int32_t) arrlen(currentGameArgs));
         platformInitFunctions(runner);
 

--- a/src/desktop/platformdefs.h
+++ b/src/desktop/platformdefs.h
@@ -19,6 +19,7 @@ bool platformGetScaledWindowSize(int32_t* outW, int32_t* outH);
 void platformSetWindowSize(int32_t width, int32_t height);
 void platformSetWindowTitle(const char* title);
 void platformSleepUntil(uint64_t time);
+void platformShowErrorDialogue(const char* message);
 
 enum GraphicsAPI {
     SOFTWARE,

--- a/src/runner.h
+++ b/src/runner.h
@@ -505,6 +505,7 @@ struct Runner {
     void (*setWindowTitle)(const char* title);
     bool (*getWindowSize)(int32_t* outW, int32_t* outH);
     void (*setWindowSize)(int32_t width, int32_t height);
+    void (*showErrorDialogue)(const char* message);
     bool (*windowHasFocus)(void);
     void (*setCursor)(int32_t cursorType);
     int32_t currentCursor;  // last value passed to window_set_cursor

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -1821,6 +1821,28 @@ static RValue builtin_show_debug_message(MAYBE_UNUSED VMContext* ctx, RValue* ar
     return RValue_makeUndefined();
 }
 
+// show_error(str, abort) - Displays an error message and optionally aborts the game
+static RValue builtin_show_error(MAYBE_UNUSED VMContext* ctx, RValue* args, int32_t argCount) {
+    if (1 > argCount) {
+        fprintf(stderr, "[show_error] Expected at least 1 argument\n");
+        return RValue_makeUndefined();
+    }
+
+    char* val = RValue_toString(args[0]);
+    bool abort = false;
+    if (2 <= argCount) abort = RValue_toBool(args[1]);
+
+    fprintf(stderr, "Game error: %s\n", val);
+    free(val);
+
+    if (abort) {
+        fprintf(stderr, "Game aborted due to show_error() call.\n");
+        exit(EXIT_FAILURE);
+    }
+
+    return RValue_makeUndefined();
+}
+
 static RValue builtin_string_length(MAYBE_UNUSED VMContext* ctx, RValue* args, int32_t argCount) {
     if (1 > argCount) return RValue_makeInt32(0);
     // GML converts non-string arguments to string before measuring length
@@ -16368,6 +16390,7 @@ void VMBuiltins_registerAll(VMContext* ctx) {
 
     // Core output
     VM_registerBuiltin(ctx, "show_debug_message", builtin_show_debug_message);
+    VM_registerBuiltin(ctx, "show_error", builtin_show_error);
 
     // String functions
     VM_registerBuiltin(ctx, "string_length", builtin_string_length);

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -1832,7 +1832,11 @@ static RValue builtin_show_error(MAYBE_UNUSED VMContext* ctx, RValue* args, int3
     bool abort = false;
     if (2 <= argCount) abort = RValue_toBool(args[1]);
 
-    fprintf(stderr, "Game error: %s\n", val);
+    fprintf(stderr, "[show_error] %s\n", val);
+    Runner* runner = ctx->runner;
+    if (runner->showErrorDialogue) {
+        runner->showErrorDialogue(val);
+    }
     free(val);
 
     if (abort) {


### PR DESCRIPTION
Adds in the debug show_error function. In GameMaker, this would open a popup window but due to this project needing to support multiple frontends, I've just made it print the error instead and optionally exit the game if the game marks it necessary.

When this is called: `show_error("Assertion failed: " + _msg, true);`, the following is output:

```
Game error: Assertion failed: vertex_format_end returned invalid format
Game aborted due to show_error() call.
```

and the game quits.