### PR TITLE
fix(vm): coerce ini_write_string value to string

### DIFF
--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -7269,10 +7269,13 @@ static RValue builtin_ini_write_string(VMContext* ctx, RValue* args, int32_t arg
 
     const char* section = (args[0].type == RVALUE_STRING ? args[0].string : "");
     const char* key = (args[1].type == RVALUE_STRING ? args[1].string : "");
-    const char* value = (args[2].type == RVALUE_STRING ? args[2].string : "");
 
+    // GameMaker accepts any value here and converts it to a string.
+    // (Deltarune's Chinese patch relies on this by passing the numeric global.names.)
+    char* value = RValue_toString(args[2]);
     Ini_setString(runner->currentIni, section, key, value);
     runner->currentIniDirty = true;
+    free(value);
     return RValue_makeUndefined();
 }
 


### PR DESCRIPTION
Fixes #415.

`ini_write_string()` silently persisted an empty string whenever the third argument was not already an `RVALUE_STRING`. Native GameMaker converts any value to a string, so GML like `ini_write_string("S", "K", 123)` must persist `K="123"`, but Butterscotch wrote `K=""`.

This broke the Chinese community patch for DELTARUNE: its in-game name-translation toggle writes the numeric `global.names` via `ini_write_string`, then immediately reads it back with `ini_read_real`, so the value always round-tripped as 0 and the option appeared dead.

The fix converts the value with `RValue_toString`, mirroring the neighboring `ini_write_real` builtin.
