### PR TITLE
change string_starts_with to use memcmp

### DIFF
--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -2334,7 +2334,14 @@ static RValue builtin_string_starts_with(MAYBE_UNUSED VMContext* ctx, RValue* ar
     char* str = RValue_toString(args[0]);
 	char* substr = RValue_toString(args[1]);
 
-    bool ret = strcmp(str, substr) == 0;
+	size_t strLen = strlen(str);
+	size_t substrLen = strlen(substr);
+	if (substrLen > strLen) {
+		free(substr);
+		free(str);
+		return RValue_makeBool(false);
+	}
+    bool ret = (memcmp(str, substr, substrLen) == 0);
 
     free(substr);
     free(str);


### PR DESCRIPTION
#392 changed string_starts_with to use strcmp instead of memcmp to fix a crash when comparing a substring that's longer than the specified string
the problem is, with strcmp, it compares both strings in their entirety rather than just the length of the second string, so something like `string_starts_with("Hello World!", "Hello");` wouldn't return true

this basically reverts it back to using memcmp while adding an additional check for the substring being longer than the string