### PR TITLE
Don't draw space character when drawing text

### DIFF
--- a/src/gl/gl_renderer.c
+++ b/src/gl/gl_renderer.c
@@ -1979,7 +1979,10 @@ static void drawText(
                 uint8_t r3 = (uint8_t) BGR_R(c4), g3 = (uint8_t) BGR_G(c4), b3 = (uint8_t) BGR_B(c4);
 
                 bool drewSuccessfully = false;
-                if (glyph->sourceWidth != 0 && glyph->sourceHeight != 0) {
+				// Don't draw spaces (0x20)
+				if (ch == 0x20) {
+					drewSuccessfully = true;
+                } else if (glyph->sourceWidth != 0 && glyph->sourceHeight != 0) {
                     float u0, v0, u1, v1;
                     float localX0, localY0;
                     GLuint glyphTexId;

--- a/src/gl/gl_renderer.c
+++ b/src/gl/gl_renderer.c
@@ -1979,8 +1979,7 @@ static void drawText(
                 uint8_t r3 = (uint8_t) BGR_R(c4), g3 = (uint8_t) BGR_G(c4), b3 = (uint8_t) BGR_B(c4);
 
                 bool drewSuccessfully = false;
-				// Don't draw spaces (0x20)
-				if (ch == 0x20) {
+				if (ch == ' ') {
 					drewSuccessfully = true;
                 } else if (glyph->sourceWidth != 0 && glyph->sourceHeight != 0) {
                     float u0, v0, u1, v1;

--- a/src/gl_legacy/gl_legacy_renderer.c
+++ b/src/gl_legacy/gl_legacy_renderer.c
@@ -1135,7 +1135,10 @@ static void glDrawText(Renderer* renderer, const char* text, float x, float y, f
 
             if (glyph != nullptr) {
                 bool drewSuccessfully = false;
-                if (glyph->sourceWidth != 0 && glyph->sourceHeight != 0) {
+				// Don't draw spaces (0x20)
+				if (ch == 0x20) {
+					drewSuccessfully = true;
+                } else if (glyph->sourceWidth != 0 && glyph->sourceHeight != 0) {
                     float u0, v0, u1, v1;
                     float localX0, localY0;
                     GLuint glyphTexId;
@@ -1277,7 +1280,10 @@ static void glDrawTextColor(Renderer* renderer, const char* text, float x, float
                 int32_t c4 = Color_lerp(_c4, _c3, leftFrac);
 
                 bool drewSuccessfully = false;
-                if (glyph->sourceWidth != 0 && glyph->sourceHeight != 0) {
+				// Don't draw spaces (0x20)
+				if (ch == 0x20) {
+					drewSuccessfully = true;
+                } else if (glyph->sourceWidth != 0 && glyph->sourceHeight != 0) {
                     float u0, v0, u1, v1;
                     float localX0, localY0;
                     GLuint glyphTexId;

--- a/src/gl_legacy/gl_legacy_renderer.c
+++ b/src/gl_legacy/gl_legacy_renderer.c
@@ -1135,8 +1135,7 @@ static void glDrawText(Renderer* renderer, const char* text, float x, float y, f
 
             if (glyph != nullptr) {
                 bool drewSuccessfully = false;
-				// Don't draw spaces (0x20)
-				if (ch == 0x20) {
+				if (ch == ' ') {
 					drewSuccessfully = true;
                 } else if (glyph->sourceWidth != 0 && glyph->sourceHeight != 0) {
                     float u0, v0, u1, v1;
@@ -1280,8 +1279,7 @@ static void glDrawTextColor(Renderer* renderer, const char* text, float x, float
                 int32_t c4 = Color_lerp(_c4, _c3, leftFrac);
 
                 bool drewSuccessfully = false;
-				// Don't draw spaces (0x20)
-				if (ch == 0x20) {
+				if (ch == ' ') {
 					drewSuccessfully = true;
                 } else if (glyph->sourceWidth != 0 && glyph->sourceHeight != 0) {
                     float u0, v0, u1, v1;

--- a/src/ps2/gs_renderer.c
+++ b/src/ps2/gs_renderer.c
@@ -1964,7 +1964,7 @@ static void gsDrawText(Renderer* renderer, const char* text, float x, float y, f
 
             if (glyph != nullptr) {
                 bool resolveOk = true;
-                if (glyph->sourceWidth > 0 && glyph->sourceHeight > 0 && ch != 0x20) {
+                if (glyph->sourceWidth > 0 && glyph->sourceHeight > 0 && ch != ' ') {
                     GSTEXTURE glyphTex;
                     float u0 = 0, v0 = 0, u1 = 0, v1 = 0;
                     float localX0, localY0;
@@ -2086,7 +2086,7 @@ static void gsDrawTextColor(Renderer* renderer, const char* text, float x, float
                 u64 textColor4 = GS_SETREG_RGBAQ(BGR_R(c4) >> 1, BGR_G(c4) >> 1, BGR_B(c4) >> 1, ga, 0x00);
 
                 bool resolveOk = true;
-                if (glyph->sourceWidth > 0 && glyph->sourceHeight > 0 && ch != 0x20) {
+                if (glyph->sourceWidth > 0 && glyph->sourceHeight > 0 && ch != ' ') {
                     GSTEXTURE glyphTex;
                     float u0 = 0, v0 = 0, u1 = 0, v1 = 0;
                     float localX0, localY0;

--- a/src/ps2/gs_renderer.c
+++ b/src/ps2/gs_renderer.c
@@ -1964,7 +1964,7 @@ static void gsDrawText(Renderer* renderer, const char* text, float x, float y, f
 
             if (glyph != nullptr) {
                 bool resolveOk = true;
-                if (glyph->sourceWidth > 0 && glyph->sourceHeight > 0) {
+                if (glyph->sourceWidth > 0 && glyph->sourceHeight > 0 && ch != 0x20) {
                     GSTEXTURE glyphTex;
                     float u0 = 0, v0 = 0, u1 = 0, v1 = 0;
                     float localX0, localY0;
@@ -2086,7 +2086,7 @@ static void gsDrawTextColor(Renderer* renderer, const char* text, float x, float
                 u64 textColor4 = GS_SETREG_RGBAQ(BGR_R(c4) >> 1, BGR_G(c4) >> 1, BGR_B(c4) >> 1, ga, 0x00);
 
                 bool resolveOk = true;
-                if (glyph->sourceWidth > 0 && glyph->sourceHeight > 0) {
+                if (glyph->sourceWidth > 0 && glyph->sourceHeight > 0 && ch != 0x20) {
                     GSTEXTURE glyphTex;
                     float u0 = 0, v0 = 0, u1 = 0, v1 = 0;
                     float localX0, localY0;


### PR DESCRIPTION
Butterscotch still draws the space character if a sprite font has it in the string map
No clue if this causes any issues, and I've only tested the gl renderer

before:
<img width="642" height="512" alt="bscotch_font_test" src="https://github.com/user-attachments/assets/9cbef7b3-eec7-4544-bed1-5e2fb384aa53" />
after:
<img width="642" height="512" alt="bscotch_font_test_fixed" src="https://github.com/user-attachments/assets/c70e8c52-5a27-4b81-a51d-590bc6e9112c" />
gms2 runner:
<img width="642" height="512" alt="bscotch_font_test_gm" src="https://github.com/user-attachments/assets/758a15cb-1261-4fcb-a0eb-3a9ce6b2840c" />