### PR TITLE
Set event type to -2 for room creation code

### DIFF
--- a/src/runner.c
+++ b/src/runner.c
@@ -1826,9 +1826,12 @@ static void initRoom(Runner* runner, int32_t roomIndex) {
         // Room creation code runs in global context, the native runner creates a fake/dummy instance for the "self"
         Instance* dummy = Instance_create(0, STRUCT_OBJECT_INDEX, 0, 0);
         runner->vmContext->currentInstance = dummy;
+        int32_t savedEventType = runner->vmContext->currentEventType;
+        runner->vmContext->currentEventType = EVENT_ROOM_CREATION;
         RValue result = VM_executeCode(runner->vmContext, room->creationCodeId);
         RValue_free(&result);
         runner->vmContext->currentInstance = nullptr;
+        runner->vmContext->currentEventType = savedEventType;
         Instance_free(dummy);
     }
 

--- a/src/runner.h
+++ b/src/runner.h
@@ -17,6 +17,7 @@
 #include "random.h"
 
 // ===[ Event Type Constants ]===
+#define EVENT_ROOM_CREATION  -2
 #define EVENT_CREATE     0
 #define EVENT_DESTROY    1
 #define EVENT_ALARM      2


### PR DESCRIPTION
This matches `Error_Show_Action` from the Windows runner binary.

<img width="290" height="162" alt="image" src="https://github.com/user-attachments/assets/69f67f31-1d7e-411e-ba4c-0bb947dbbbef" />
