### PR TITLE
flowery cutscene fix in room_dw_post_fountain_close

### DIFF
--- a/src/renderer.h
+++ b/src/renderer.h
@@ -585,11 +585,11 @@ static inline int32_t Renderer_resolveObjectTPAGIndex(DataWin* dataWin, RoomTile
 }
 
 // Draws a tiled background
-static inline void Renderer_drawBackgroundTiled(Renderer* renderer, int32_t tpagIndex, float bgX, float bgY, float xscale, float yscale, bool tileX, bool tileY, float roomW, float roomH, float alpha) {
+static inline void Renderer_drawBackgroundTiled(Renderer* renderer, int32_t tpagIndex, float bgX, float bgY, float xscale, float yscale, bool tileX, bool tileY, float roomW, float roomH, uint32_t blend, float alpha) {
     DataWin* dw = renderer->dataWin;
     if (0 > tpagIndex || (uint32_t) tpagIndex >= dw->tpag.count) return;
 
-    renderer->vtable->drawSpriteTiled(renderer, tpagIndex, 0.0f, 0.0f, bgX, bgY, xscale, yscale, tileX, tileY, roomW, roomH, 0xFFFFFFu, alpha);
+    renderer->vtable->drawSpriteTiled(renderer, tpagIndex, 0.0f, 0.0f, bgX, bgY, xscale, yscale, tileX, tileY, roomW, roomH, blend, alpha);
 }
 
 // Draws a tiled sprite across the room

--- a/src/runner.c
+++ b/src/runner.c
@@ -599,7 +599,7 @@ static void drawBackground(
         float yscale = roomH / (float) tpag->boundingHeight;
         runner->renderer->vtable->drawSprite(runner->renderer, tpagIndex, 0.0f, 0.0f, 0.0f, 0.0f, xscale, yscale, 0.0f, blend, alpha);
     } else if (tileX || tileY) {
-        Renderer_drawBackgroundTiled(runner->renderer, tpagIndex, layerOffsetX + backgroundX, layerOffsetY + backgroundY, xScale, yScale, tileX, tileY, roomW, roomH, alpha);
+        Renderer_drawBackgroundTiled(runner->renderer, tpagIndex, layerOffsetX + backgroundX, layerOffsetY + backgroundY, xScale, yScale, tileX, tileY, roomW, roomH, blend, alpha);
     } else {
         // Single placement
         runner->renderer->vtable->drawSprite(runner->renderer, tpagIndex, layerOffsetX + backgroundX, layerOffsetY + backgroundY, 0.0f, 0.0f, xScale, yScale, 0.0f, blend, alpha);


### PR DESCRIPTION
fixes a issue with chapter 5 where the moving pillars appear before flowery chases the knight in room_dw_post_fountain_close

cause: Renderer_drawBackgroundTiled in renderer.h hardcoded the blend color to 0xFFFFFF

before:
[Screencast_20260828_154810.webm](https://github.com/user-attachments/assets/384775df-0dcb-4bba-add2-5d3fd529caf0)

now:
[Screencast_20260828_162330.webm](https://github.com/user-attachments/assets/c6d78d62-e2b1-434a-96e9-b3b920a6539f)
