### PR TITLE
perf(gl): actual CPU state tracking wrappers

### DIFF
--- a/src/gl/gl_renderer.c
+++ b/src/gl/gl_renderer.c
@@ -22,6 +22,7 @@
 #include "image_decoder.h"
 #include "gl_common.h"
 #include "gl_wrappers.h"
+#include "gl_state.h"
 
 // ===[ Constants ]===
 #define MAX_QUADS 4096

--- a/src/gl/gl_renderer.c
+++ b/src/gl/gl_renderer.c
@@ -449,6 +449,8 @@ static void glInit(Renderer* renderer, DataWin* dataWin) {
         abort();
     }
 
+    GLState_init();
+
     char vertSrc[1024];
     char fragSrc[1024];
     const char* vertHeader = "";

--- a/src/gl_common/gl_state.h
+++ b/src/gl_common/gl_state.h
@@ -1,16 +1,18 @@
 #ifndef _BS_GL_STATE_H
 #define _BS_GL_STATE_H
 
+#define GL_MAX_TEXTURE_2D 32
+
 static GLenum activeTextureSlot = GL_TEXTURE0;
 static GLint viewport[4] = {-1, -1, -1, -1};
 static GLint scissor[4] = {-1, -1, -1, -1};
 static GLuint currentReadFb = 0;
 static GLuint currentDrawFb = 0;
-static GLuint boundTextures2D[32] = {0};
+static GLuint boundTextures2D[GL_MAX_TEXTURE_2D] = {0};
 static GLboolean blend = GL_FALSE;
 static GLboolean depthTest = GL_FALSE;
 static GLboolean scissorTest = GL_FALSE;
-static GLboolean texture2D = GL_FALSE;
+static GLboolean texture2D[GL_MAX_TEXTURE_2D] = {GL_FALSE};
 
 static void cached_glViewport(int x, int y, int width, int height) {
     if (viewport[0] == x && viewport[1] == y && viewport[2] == width && viewport[3] == height) return;
@@ -118,8 +120,11 @@ static void cached_glEnable(GLenum cap) {
             scissorTest = GL_TRUE;
             break;
         case GL_TEXTURE_2D:
-            if (texture2D) return;
-            texture2D = GL_TRUE;
+            int slotIndex = (int)activeTextureSlot - GL_TEXTURE0;
+            if (slotIndex >= 0 && slotIndex < GL_MAX_TEXTURE_2D) {
+                if (texture2D[slotIndex]) return;
+                texture2D[slotIndex] = GL_TRUE;
+            }
             break;
     }
     glEnable(cap);
@@ -143,8 +148,11 @@ static void cached_glDisable(GLenum cap) {
             scissorTest = GL_FALSE;
             break;
         case GL_TEXTURE_2D:
-            if (!texture2D) return;
-            texture2D = GL_FALSE;
+            int slotIndex = (int)activeTextureSlot - GL_TEXTURE0;
+            if (slotIndex >= 0 && slotIndex < GL_MAX_TEXTURE_2D) {
+                if (!texture2D[slotIndex]) return;
+                texture2D[slotIndex] = GL_FALSE;
+            }
             break;
     }
     glDisable(cap);
@@ -161,8 +169,13 @@ static inline GLboolean cached_glIsEnabled(GLenum cap) {
             return depthTest;
         case GL_SCISSOR_TEST:
             return scissorTest;
-        case GL_TEXTURE_2D:
-            return texture2D;
+        case GL_TEXTURE_2D: {
+            int slotIndex = (int)activeTextureSlot - GL_TEXTURE0;
+            if (slotIndex >= 0 && slotIndex < GL_MAX_TEXTURE_UNITS) {
+                return texture2D[slotIndex];
+            }
+            return glIsEnabled(cap);
+        }
         default: 
             return glIsEnabled(cap);
     }

--- a/src/gl_common/gl_state.h
+++ b/src/gl_common/gl_state.h
@@ -1,0 +1,174 @@
+#ifndef _BS_GL_STATE_H
+#define _BS_GL_STATE_H
+
+static GLenum activeTextureSlot = GL_TEXTURE0;
+static GLint viewport[4];
+static GLint scissor[4];
+static GLuint currentReadFb = 0;
+static GLuint currentDrawFb = 0;
+static GLuint boundTextures2D[32];
+static GLboolean blend = GL_FALSE;
+static GLboolean depthTest = GL_FALSE;
+static GLboolean scissorTest = GL_FALSE;
+static GLboolean texture2D = GL_FALSE;
+
+static void cached_glViewport(int x, int y, int width, int height) {
+    if (viewport[0] == x && viewport[1] == y && viewport[2] == width && viewport[3] == height) return;
+    glViewport(x, y, width, height);
+    viewport[0] = x;
+    viewport[1] = y;
+    viewport[2] = width;
+    viewport[3] = height;
+}
+#undef glViewport
+#define glViewport cached_glViewport
+
+static void cached_glScissor(int x, int y, int width, int height) {
+    if (scissor[0] == x && scissor[1] == y && scissor[2] == width && scissor[3] == height) return;
+    glScissor(x, y, width, height);
+    scissor[0] = x;
+    scissor[1] = y;
+    scissor[2] = width;
+    scissor[3] = height;
+}
+#undef glScissor
+#define glScissor cached_glScissor
+
+static void cached_glBindFramebuffer(GLenum type, GLuint framebuffer) {
+    switch (type) {
+        case GL_READ_FRAMEBUFFER:
+            if (currentReadFb == framebuffer) return;
+            currentReadFb = framebuffer;
+            break;
+        case GL_DRAW_FRAMEBUFFER:
+            if (currentDrawFb == framebuffer) return;
+            currentDrawFb = framebuffer;
+            break;
+        case GL_FRAMEBUFFER:
+            if (currentReadFb == framebuffer && currentDrawFb == framebuffer) return;
+            currentReadFb = framebuffer;
+            currentDrawFb = framebuffer;
+            break;
+        default:
+            return;
+    }
+
+    glBindFramebuffer(type, framebuffer);
+}
+#undef glBindFramebuffer
+#define glBindFramebuffer cached_glBindFramebuffer
+
+static void cached_glGetIntegerv(GLenum pname, GLint* params) {
+    if (!params) return;
+
+    switch (pname) {
+        case GL_VIEWPORT:
+            params[0] = viewport[0];
+            params[1] = viewport[1];
+            params[2] = viewport[2];
+            params[3] = viewport[3];
+            return;
+        case GL_FRAMEBUFFER_BINDING:
+            params[0] = (GLint)currentDrawFb;
+            return;
+        case GL_READ_FRAMEBUFFER_BINDING:
+            params[0] = (GLint)currentReadFb;
+            return;
+        default:
+            glGetIntegerv(pname, params);
+            break;
+    }
+}
+#undef glGetIntegerv
+#define glGetIntegerv cached_glGetIntegerv
+
+static void cached_glActiveTexture(GLenum texture) {
+    if (activeTextureSlot == texture) return;
+    glActiveTexture(texture);
+    activeTextureSlot = texture;
+}
+
+#undef glActiveTexture
+#define glActiveTexture cached_glActiveTexture
+
+static void cached_glBindTexture(GLenum target, GLuint texture) {
+    if (target == GL_TEXTURE_2D) {
+        int slot_idx = activeTextureSlot - GL_TEXTURE0;
+        if (boundTextures2D[slot_idx] == texture) return;
+        boundTextures2D[slot_idx] = texture;
+    }
+    glBindTexture(target, texture);
+}
+
+#undef glBindTexture
+#define glBindTexture cached_glBindTexture
+
+static void cached_glEnable(GLenum cap) {
+    switch (cap) {
+        case GL_BLEND:
+            if (blend) return;
+            blend = GL_TRUE;
+            break;
+        case GL_DEPTH_TEST:
+            if (depthTest) return;
+            depthTest = GL_TRUE;
+            break;
+        case GL_SCISSOR_TEST:
+            if (scissorTest) return;
+            scissorTest = GL_TRUE;
+            break;
+        case GL_TEXTURE_2D:
+            if (texture2D) return;
+            texture2D = GL_TRUE;
+            break;
+    }
+    glEnable(cap);
+}
+
+#undef glEnable
+#define glEnable cached_glEnable
+
+static void cached_glDisable(GLenum cap) {
+    switch (cap) {
+        case GL_BLEND:
+            if (!blend) return;
+            blend = GL_FALSE;
+            break;
+        case GL_DEPTH_TEST:
+            if (!depthTest) return;
+            depthTest = GL_FALSE;
+            break;
+        case GL_SCISSOR_TEST:
+            if (!scissorTest) return;
+            scissorTest = GL_FALSE;
+            break;
+        case GL_TEXTURE_2D:
+            if (!texture2D) return;
+            texture2D = GL_FALSE;
+            break;
+    }
+    glDisable(cap);
+}
+
+#undef glDisable
+#define glDisable cached_glDisable
+
+static inline GLboolean cached_glIsEnabled(GLenum cap) {
+    switch (cap) {
+        case GL_BLEND:
+            return blend;
+        case GL_DEPTH_TEST:
+            return depthTest;
+        case GL_SCISSOR_TEST:
+            return scissorTest;
+        case GL_TEXTURE_2D:
+            return texture2D;
+        default: 
+            return glIsEnabled(cap);
+    }
+}
+
+#undef glIsEnabled
+#define glIsEnabled cached_glIsEnabled
+
+#endif // _BS_GL_STATE_H

--- a/src/gl_common/gl_state.h
+++ b/src/gl_common/gl_state.h
@@ -113,21 +113,24 @@ static void cached_glEnable(GLenum cap) {
             if (blend) return;
             blend = GL_TRUE;
             break;
-        case GL_DEPTH_TEST:
+        case GL_DEPTH_TEST: {
             if (depthTest) return;
             depthTest = GL_TRUE;
             break;
-        case GL_SCISSOR_TEST:
+        }
+        case GL_SCISSOR_TEST: {
             if (scissorTest) return;
             scissorTest = GL_TRUE;
             break;
-        case GL_TEXTURE_2D:
+        }
+        case GL_TEXTURE_2D: {
             int slotIndex = (int)activeTextureSlot - GL_TEXTURE0;
             if (slotIndex >= 0 && slotIndex < GL_MAX_TEXTURE_2D) {
                 if (texture2D[slotIndex]) return;
                 texture2D[slotIndex] = GL_TRUE;
             }
             break;
+        }
     }
     glEnable(cap);
 }
@@ -149,13 +152,14 @@ static void cached_glDisable(GLenum cap) {
             if (!scissorTest) return;
             scissorTest = GL_FALSE;
             break;
-        case GL_TEXTURE_2D:
+        case GL_TEXTURE_2D: {
             int slotIndex = (int)activeTextureSlot - GL_TEXTURE0;
             if (slotIndex >= 0 && slotIndex < GL_MAX_TEXTURE_2D) {
                 if (!texture2D[slotIndex]) return;
                 texture2D[slotIndex] = GL_FALSE;
             }
             break;
+        }
     }
     glDisable(cap);
 }
@@ -178,7 +182,7 @@ static inline GLboolean cached_glIsEnabled(GLenum cap) {
             }
             return glIsEnabled(cap);
         }
-        default: 
+        default:
             return glIsEnabled(cap);
     }
 }

--- a/src/gl_common/gl_state.h
+++ b/src/gl_common/gl_state.h
@@ -4,10 +4,16 @@
 #define GL_MAX_TEXTURE_2D 32
 
 static GLenum activeTextureSlot = GL_TEXTURE0;
+static GLenum blendSrcRGB = GL_ONE, blendDstRGB = GL_ZERO;
+static GLenum blendSrcAlpha = GL_ONE, blendDstAlpha = GL_ZERO;
+static GLenum blendEqRGB = GL_FUNC_ADD, blendEqAlpha = GL_FUNC_ADD;
+static GLclampf clearColor[4] = {-1.0f, -1.0f, -1.0f, -1.0f};
 static GLint viewport[4] = {-1, -1, -1, -1};
 static GLint scissor[4] = {-1, -1, -1, -1};
 static GLuint currentReadFb = 0;
 static GLuint currentDrawFb = 0;
+static GLuint currentProgram = 0;
+static GLuint currentVAO = 0xFFFFFFFF;
 static GLuint boundTextures2D[GL_MAX_TEXTURE_2D] = {0};
 static GLboolean blend = GL_FALSE;
 static GLboolean depthTest = GL_FALSE;
@@ -106,6 +112,79 @@ static inline void cached_glBindTexture(GLenum target, GLuint texture) {
 
 #undef glBindTexture
 #define glBindTexture cached_glBindTexture
+
+static inline void cached_glUseProgram(GLuint program) {
+    if (currentProgram == program) return;
+    glUseProgram(program);
+    currentProgram = program;
+}
+
+#undef glUseProgram
+#define glUseProgram cached_glUseProgram
+
+static inline void cached_glBindVertexArray(GLuint vao) {
+    if (currentVAO == vao) return;
+    glBindVertexArray(vao);
+    currentVAO = vao;
+}
+
+#undef glBindVertexArray
+#define glBindVertexArray cached_glBindVertexArray
+
+static inline void cached_glDeleteVertexArrays(GLsizei n, const GLuint* arrays) {
+    for (GLsizei i = 0; i < n; i++) {
+        if (currentVAO == arrays[i]) currentVAO = 0;
+    }
+    glDeleteVertexArrays(n, arrays);
+}
+#undef glDeleteVertexArrays
+#define glDeleteVertexArrays cached_glDeleteVertexArrays
+
+static inline void cached_glBlendFuncSeparate(GLenum srcRGB, GLenum dstRGB, GLenum srcAlpha, GLenum dstAlpha) {
+    if (blendSrcRGB == srcRGB && blendDstRGB == dstRGB && blendSrcAlpha == srcAlpha && blendDstAlpha == dstAlpha) return;
+    
+    glBlendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha);
+    
+    blendSrcRGB   = srcRGB;
+    blendDstRGB   = dstRGB;
+    blendSrcAlpha = srcAlpha;
+    blendDstAlpha = dstAlpha;
+}
+#undef glBlendFuncSeparate
+#define glBlendFuncSeparate cached_glBlendFuncSeparate
+
+static inline void cached_glBlendFunc(GLenum sfactor, GLenum dfactor) {
+    cached_glBlendFuncSeparate(sfactor, dfactor, sfactor, dfactor);
+}
+#undef glBlendFunc
+#define glBlendFunc cached_glBlendFunc
+
+static inline void cached_glBlendEquationSeparate(GLenum eqRGB, GLenum eqAlpha) {
+    if (blendEqRGB == eqRGB && blendEqAlpha == eqAlpha) return;
+    glBlendEquationSeparate(eqRGB, eqAlpha);
+    blendEqRGB = eqRGB;
+    blendEqAlpha = eqAlpha;
+}
+#undef glBlendEquationSeparate
+#define glBlendEquationSeparate cached_glBlendEquationSeparate
+
+static inline void cached_glBlendEquation(GLenum mode) {
+    cached_glBlendEquationSeparate(mode, mode);
+}
+#undef glBlendEquation
+#define glBlendEquation cached_glBlendEquation
+
+static inline void cached_glClearColor(GLclampf r, GLclampf g, GLclampf b, GLclampf a) {
+    if (clearColor[0] == r && clearColor[1] == g && clearColor[2] == b && clearColor[3] == a) return;
+    glClearColor(r, g, b, a);
+    clearColor[0] = r;
+    clearColor[1] = g;
+    clearColor[2] = b;
+    clearColor[3] = a;
+}
+
+#undef glClearColor
+#define glClearColor cached_glClearColor
 
 static inline void cached_glEnable(GLenum cap) {
     switch (cap) {

--- a/src/gl_common/gl_state.h
+++ b/src/gl_common/gl_state.h
@@ -171,7 +171,7 @@ static inline GLboolean cached_glIsEnabled(GLenum cap) {
             return scissorTest;
         case GL_TEXTURE_2D: {
             int slotIndex = (int)activeTextureSlot - GL_TEXTURE0;
-            if (slotIndex >= 0 && slotIndex < GL_MAX_TEXTURE_UNITS) {
+            if (slotIndex >= 0 && slotIndex < GL_MAX_TEXTURE_2D) {
                 return texture2D[slotIndex];
             }
             return glIsEnabled(cap);

--- a/src/gl_common/gl_state.h
+++ b/src/gl_common/gl_state.h
@@ -2,11 +2,11 @@
 #define _BS_GL_STATE_H
 
 static GLenum activeTextureSlot = GL_TEXTURE0;
-static GLint viewport[4];
-static GLint scissor[4];
+static GLint viewport[4] = {-1, -1, -1, -1};
+static GLint scissor[4] = {-1, -1, -1, -1};
 static GLuint currentReadFb = 0;
 static GLuint currentDrawFb = 0;
-static GLuint boundTextures2D[32];
+static GLuint boundTextures2D[32] = {0};
 static GLboolean blend = GL_FALSE;
 static GLboolean depthTest = GL_FALSE;
 static GLboolean scissorTest = GL_FALSE;

--- a/src/gl_common/gl_state.h
+++ b/src/gl_common/gl_state.h
@@ -95,9 +95,11 @@ static void cached_glActiveTexture(GLenum texture) {
 
 static void cached_glBindTexture(GLenum target, GLuint texture) {
     if (target == GL_TEXTURE_2D) {
-        int slot_idx = activeTextureSlot - GL_TEXTURE0;
-        if (boundTextures2D[slot_idx] == texture) return;
-        boundTextures2D[slot_idx] = texture;
+        int slotIndex = activeTextureSlot - GL_TEXTURE0;
+        if (slotIndex >= 0 && slotIndex < GL_MAX_TEXTURE_2D) {
+            if (boundTextures2D[slotIndex] == texture) return;
+            boundTextures2D[slotIndex] = texture;
+        }
     }
     glBindTexture(target, texture);
 }

--- a/src/gl_common/gl_state.h
+++ b/src/gl_common/gl_state.h
@@ -14,7 +14,7 @@ static GLboolean depthTest = GL_FALSE;
 static GLboolean scissorTest = GL_FALSE;
 static GLboolean texture2D[GL_MAX_TEXTURE_2D] = {GL_FALSE};
 
-static void cached_glViewport(int x, int y, int width, int height) {
+static inline void cached_glViewport(int x, int y, int width, int height) {
     if (viewport[0] == x && viewport[1] == y && viewport[2] == width && viewport[3] == height) return;
     glViewport(x, y, width, height);
     viewport[0] = x;
@@ -25,7 +25,7 @@ static void cached_glViewport(int x, int y, int width, int height) {
 #undef glViewport
 #define glViewport cached_glViewport
 
-static void cached_glScissor(int x, int y, int width, int height) {
+static inline void cached_glScissor(int x, int y, int width, int height) {
     if (scissor[0] == x && scissor[1] == y && scissor[2] == width && scissor[3] == height) return;
     glScissor(x, y, width, height);
     scissor[0] = x;
@@ -36,7 +36,7 @@ static void cached_glScissor(int x, int y, int width, int height) {
 #undef glScissor
 #define glScissor cached_glScissor
 
-static void cached_glBindFramebuffer(GLenum type, GLuint framebuffer) {
+static inline void cached_glBindFramebuffer(GLenum type, GLuint framebuffer) {
     switch (type) {
         case GL_READ_FRAMEBUFFER:
             if (currentReadFb == framebuffer) return;
@@ -60,7 +60,7 @@ static void cached_glBindFramebuffer(GLenum type, GLuint framebuffer) {
 #undef glBindFramebuffer
 #define glBindFramebuffer cached_glBindFramebuffer
 
-static void cached_glGetIntegerv(GLenum pname, GLint* params) {
+static inline void cached_glGetIntegerv(GLenum pname, GLint* params) {
     if (!params) return;
 
     switch (pname) {
@@ -84,7 +84,7 @@ static void cached_glGetIntegerv(GLenum pname, GLint* params) {
 #undef glGetIntegerv
 #define glGetIntegerv cached_glGetIntegerv
 
-static void cached_glActiveTexture(GLenum texture) {
+static inline void cached_glActiveTexture(GLenum texture) {
     if (activeTextureSlot == texture) return;
     glActiveTexture(texture);
     activeTextureSlot = texture;
@@ -93,7 +93,7 @@ static void cached_glActiveTexture(GLenum texture) {
 #undef glActiveTexture
 #define glActiveTexture cached_glActiveTexture
 
-static void cached_glBindTexture(GLenum target, GLuint texture) {
+static inline void cached_glBindTexture(GLenum target, GLuint texture) {
     if (target == GL_TEXTURE_2D) {
         int slotIndex = activeTextureSlot - GL_TEXTURE0;
         if (slotIndex >= 0 && slotIndex < GL_MAX_TEXTURE_2D) {
@@ -107,7 +107,7 @@ static void cached_glBindTexture(GLenum target, GLuint texture) {
 #undef glBindTexture
 #define glBindTexture cached_glBindTexture
 
-static void cached_glEnable(GLenum cap) {
+static inline void cached_glEnable(GLenum cap) {
     switch (cap) {
         case GL_BLEND:
             if (blend) return;
@@ -138,7 +138,7 @@ static void cached_glEnable(GLenum cap) {
 #undef glEnable
 #define glEnable cached_glEnable
 
-static void cached_glDisable(GLenum cap) {
+static inline void cached_glDisable(GLenum cap) {
     switch (cap) {
         case GL_BLEND:
             if (!blend) return;

--- a/src/gl_common/gl_state.h
+++ b/src/gl_common/gl_state.h
@@ -3,41 +3,84 @@
 
 #define GL_MAX_TEXTURE_2D 32
 
-static GLenum activeTextureSlot = GL_TEXTURE0;
-static GLenum blendSrcRGB = GL_ONE, blendDstRGB = GL_ZERO;
-static GLenum blendSrcAlpha = GL_ONE, blendDstAlpha = GL_ZERO;
-static GLenum blendEqRGB = GL_FUNC_ADD, blendEqAlpha = GL_FUNC_ADD;
-static GLclampf clearColor[4] = {-1.0f, -1.0f, -1.0f, -1.0f};
-static GLint viewport[4] = {-1, -1, -1, -1};
-static GLint scissor[4] = {-1, -1, -1, -1};
-static GLuint currentReadFb = 0;
-static GLuint currentDrawFb = 0;
-static GLuint currentProgram = 0;
-static GLuint currentVAO = 0xFFFFFFFF;
-static GLuint boundTextures2D[GL_MAX_TEXTURE_2D] = {0};
-static GLboolean blend = GL_FALSE;
-static GLboolean depthTest = GL_FALSE;
-static GLboolean scissorTest = GL_FALSE;
-static GLboolean texture2D[GL_MAX_TEXTURE_2D] = {GL_FALSE};
+typedef struct {
+    GLenum activeTextureSlot;
+    GLenum blendSrcRGB;
+    GLenum blendDstRGB;
+    GLenum blendSrcAlpha;
+    GLenum blendDstAlpha;
+    GLenum blendEqRGB;
+    GLenum blendEqAlpha;
+    GLclampf clearColor[4];
+    GLint viewport[4];
+    GLint scissor[4];
+    GLuint currentReadFb;
+    GLuint currentDrawFb;
+    GLuint currentProgram;
+    GLuint currentVAO;
+    GLuint boundTextures2D[GL_MAX_TEXTURE_2D];
+    GLboolean blend;
+    GLboolean depthTest;
+    GLboolean scissorTest;
+    GLboolean texture2D[GL_MAX_TEXTURE_2D];
+} GLStateCache;
+
+static GLStateCache glState;
+static GLboolean glStateInitialized = GL_FALSE;
+
+static inline void GLState_init(void) {    
+    glState.activeTextureSlot = GL_TEXTURE0;
+    glState.blendSrcRGB       = GL_ONE;
+    glState.blendDstRGB       = GL_ZERO;
+    glState.blendSrcAlpha     = GL_ONE;
+    glState.blendDstAlpha     = GL_ZERO;
+    glState.blendEqRGB        = GL_FUNC_ADD;
+    glState.blendEqAlpha      = GL_FUNC_ADD;
+    
+    glState.clearColor[0] = -1.0f; glState.clearColor[1] = -1.0f; 
+    glState.clearColor[2] = -1.0f; glState.clearColor[3] = -1.0f;
+    
+    glState.viewport[0] = -1; glState.viewport[1] = -1; 
+    glState.viewport[2] = -1; glState.viewport[3] = -1;
+    
+    glState.scissor[0]  = -1; glState.scissor[1]  = -1; 
+    glState.scissor[2]  = -1; glState.scissor[3]  = -1;
+    
+    glState.currentReadFb  = 0;
+    glState.currentDrawFb  = 0;
+    glState.currentProgram = 0;
+    glState.currentVAO     = 0xFFFFFFFF;
+    
+    glState.blend       = GL_FALSE;
+    glState.depthTest   = GL_FALSE;
+    glState.scissorTest = GL_FALSE;
+    
+    for (int i = 0; i < GL_MAX_TEXTURE_2D; i++) {
+        glState.boundTextures2D[i] = 0;
+        glState.texture2D[i]       = GL_FALSE;
+    }
+    
+    glStateInitialized = GL_TRUE;
+}
 
 static inline void cached_glViewport(int x, int y, int width, int height) {
-    if (viewport[0] == x && viewport[1] == y && viewport[2] == width && viewport[3] == height) return;
+    if (glState.viewport[0] == x && glState.viewport[1] == y && glState.viewport[2] == width && glState.viewport[3] == height) return;
     glViewport(x, y, width, height);
-    viewport[0] = x;
-    viewport[1] = y;
-    viewport[2] = width;
-    viewport[3] = height;
+    glState.viewport[0] = x;
+    glState.viewport[1] = y;
+    glState.viewport[2] = width;
+    glState.viewport[3] = height;
 }
 #undef glViewport
 #define glViewport cached_glViewport
 
 static inline void cached_glScissor(int x, int y, int width, int height) {
-    if (scissor[0] == x && scissor[1] == y && scissor[2] == width && scissor[3] == height) return;
+    if (glState.scissor[0] == x && glState.scissor[1] == y && glState.scissor[2] == width && glState.scissor[3] == height) return;
     glScissor(x, y, width, height);
-    scissor[0] = x;
-    scissor[1] = y;
-    scissor[2] = width;
-    scissor[3] = height;
+    glState.scissor[0] = x;
+    glState.scissor[1] = y;
+    glState.scissor[2] = width;
+    glState.scissor[3] = height;
 }
 #undef glScissor
 #define glScissor cached_glScissor
@@ -45,22 +88,21 @@ static inline void cached_glScissor(int x, int y, int width, int height) {
 static inline void cached_glBindFramebuffer(GLenum type, GLuint framebuffer) {
     switch (type) {
         case GL_READ_FRAMEBUFFER:
-            if (currentReadFb == framebuffer) return;
-            currentReadFb = framebuffer;
+            if (glState.currentReadFb == framebuffer) return;
+            glState.currentReadFb = framebuffer;
             break;
         case GL_DRAW_FRAMEBUFFER:
-            if (currentDrawFb == framebuffer) return;
-            currentDrawFb = framebuffer;
+            if (glState.currentDrawFb == framebuffer) return;
+            glState.currentDrawFb = framebuffer;
             break;
         case GL_FRAMEBUFFER:
-            if (currentReadFb == framebuffer && currentDrawFb == framebuffer) return;
-            currentReadFb = framebuffer;
-            currentDrawFb = framebuffer;
+            if (glState.currentReadFb == framebuffer && glState.currentDrawFb == framebuffer) return;
+            glState.currentReadFb = framebuffer;
+            glState.currentDrawFb = framebuffer;
             break;
         default:
             return;
     }
-
     glBindFramebuffer(type, framebuffer);
 }
 #undef glBindFramebuffer
@@ -71,16 +113,16 @@ static inline void cached_glGetIntegerv(GLenum pname, GLint* params) {
 
     switch (pname) {
         case GL_VIEWPORT:
-            params[0] = viewport[0];
-            params[1] = viewport[1];
-            params[2] = viewport[2];
-            params[3] = viewport[3];
+            params[0] = glState.viewport[0];
+            params[1] = glState.viewport[1];
+            params[2] = glState.viewport[2];
+            params[3] = glState.viewport[3];
             return;
         case GL_FRAMEBUFFER_BINDING:
-            params[0] = (GLint)currentDrawFb;
+            params[0] = (GLint)glState.currentDrawFb;
             return;
         case GL_READ_FRAMEBUFFER_BINDING:
-            params[0] = (GLint)currentReadFb;
+            params[0] = (GLint)glState.currentReadFb;
             return;
         default:
             glGetIntegerv(pname, params);
@@ -91,49 +133,45 @@ static inline void cached_glGetIntegerv(GLenum pname, GLint* params) {
 #define glGetIntegerv cached_glGetIntegerv
 
 static inline void cached_glActiveTexture(GLenum texture) {
-    if (activeTextureSlot == texture) return;
+    if (glState.activeTextureSlot == texture) return;
     glActiveTexture(texture);
-    activeTextureSlot = texture;
+    glState.activeTextureSlot = texture;
 }
-
 #undef glActiveTexture
 #define glActiveTexture cached_glActiveTexture
 
 static inline void cached_glBindTexture(GLenum target, GLuint texture) {
     if (target == GL_TEXTURE_2D) {
-        int slotIndex = activeTextureSlot - GL_TEXTURE0;
+        int slotIndex = glState.activeTextureSlot - GL_TEXTURE0;
         if (slotIndex >= 0 && slotIndex < GL_MAX_TEXTURE_2D) {
-            if (boundTextures2D[slotIndex] == texture) return;
-            boundTextures2D[slotIndex] = texture;
+            if (glState.boundTextures2D[slotIndex] == texture) return;
+            glState.boundTextures2D[slotIndex] = texture;
         }
     }
     glBindTexture(target, texture);
 }
-
 #undef glBindTexture
 #define glBindTexture cached_glBindTexture
 
 static inline void cached_glUseProgram(GLuint program) {
-    if (currentProgram == program) return;
+    if (glState.currentProgram == program) return;
     glUseProgram(program);
-    currentProgram = program;
+    glState.currentProgram = program;
 }
-
 #undef glUseProgram
 #define glUseProgram cached_glUseProgram
 
 static inline void cached_glBindVertexArray(GLuint vao) {
-    if (currentVAO == vao) return;
+    if (glState.currentVAO == vao) return;
     glBindVertexArray(vao);
-    currentVAO = vao;
+    glState.currentVAO = vao;
 }
-
 #undef glBindVertexArray
 #define glBindVertexArray cached_glBindVertexArray
 
 static inline void cached_glDeleteVertexArrays(GLsizei n, const GLuint* arrays) {
     for (GLsizei i = 0; i < n; i++) {
-        if (currentVAO == arrays[i]) currentVAO = 0;
+        if (glState.currentVAO == arrays[i]) glState.currentVAO = 0;
     }
     glDeleteVertexArrays(n, arrays);
 }
@@ -141,14 +179,15 @@ static inline void cached_glDeleteVertexArrays(GLsizei n, const GLuint* arrays) 
 #define glDeleteVertexArrays cached_glDeleteVertexArrays
 
 static inline void cached_glBlendFuncSeparate(GLenum srcRGB, GLenum dstRGB, GLenum srcAlpha, GLenum dstAlpha) {
-    if (blendSrcRGB == srcRGB && blendDstRGB == dstRGB && blendSrcAlpha == srcAlpha && blendDstAlpha == dstAlpha) return;
+    if (glState.blendSrcRGB == srcRGB && glState.blendDstRGB == dstRGB && 
+        glState.blendSrcAlpha == srcAlpha && glState.blendDstAlpha == dstAlpha) return;
     
     glBlendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha);
     
-    blendSrcRGB   = srcRGB;
-    blendDstRGB   = dstRGB;
-    blendSrcAlpha = srcAlpha;
-    blendDstAlpha = dstAlpha;
+    glState.blendSrcRGB   = srcRGB;
+    glState.blendDstRGB   = dstRGB;
+    glState.blendSrcAlpha = srcAlpha;
+    glState.blendDstAlpha = dstAlpha;
 }
 #undef glBlendFuncSeparate
 #define glBlendFuncSeparate cached_glBlendFuncSeparate
@@ -160,10 +199,10 @@ static inline void cached_glBlendFunc(GLenum sfactor, GLenum dfactor) {
 #define glBlendFunc cached_glBlendFunc
 
 static inline void cached_glBlendEquationSeparate(GLenum eqRGB, GLenum eqAlpha) {
-    if (blendEqRGB == eqRGB && blendEqAlpha == eqAlpha) return;
+    if (glState.blendEqRGB == eqRGB && glState.blendEqAlpha == eqAlpha) return;
     glBlendEquationSeparate(eqRGB, eqAlpha);
-    blendEqRGB = eqRGB;
-    blendEqAlpha = eqAlpha;
+    glState.blendEqRGB = eqRGB;
+    glState.blendEqAlpha = eqAlpha;
 }
 #undef glBlendEquationSeparate
 #define glBlendEquationSeparate cached_glBlendEquationSeparate
@@ -175,89 +214,81 @@ static inline void cached_glBlendEquation(GLenum mode) {
 #define glBlendEquation cached_glBlendEquation
 
 static inline void cached_glClearColor(GLclampf r, GLclampf g, GLclampf b, GLclampf a) {
-    if (clearColor[0] == r && clearColor[1] == g && clearColor[2] == b && clearColor[3] == a) return;
+    if (glState.clearColor[0] == r && glState.clearColor[1] == g && glState.clearColor[2] == b && glState.clearColor[3] == a) return;
     glClearColor(r, g, b, a);
-    clearColor[0] = r;
-    clearColor[1] = g;
-    clearColor[2] = b;
-    clearColor[3] = a;
+    glState.clearColor[0] = r;
+    glState.clearColor[1] = g;
+    glState.clearColor[2] = b;
+    glState.clearColor[3] = a;
 }
-
 #undef glClearColor
 #define glClearColor cached_glClearColor
 
 static inline void cached_glEnable(GLenum cap) {
     switch (cap) {
         case GL_BLEND:
-            if (blend) return;
-            blend = GL_TRUE;
+            if (glState.blend) return;
+            glState.blend = GL_TRUE;
             break;
-        case GL_DEPTH_TEST: {
-            if (depthTest) return;
-            depthTest = GL_TRUE;
+        case GL_DEPTH_TEST:
+            if (glState.depthTest) return;
+            glState.depthTest = GL_TRUE;
             break;
-        }
-        case GL_SCISSOR_TEST: {
-            if (scissorTest) return;
-            scissorTest = GL_TRUE;
+        case GL_SCISSOR_TEST:
+            if (glState.scissorTest) return;
+            glState.scissorTest = GL_TRUE;
             break;
-        }
         case GL_TEXTURE_2D: {
-            int slotIndex = (int)activeTextureSlot - GL_TEXTURE0;
+            int slotIndex = (int)glState.activeTextureSlot - GL_TEXTURE0;
             if (slotIndex >= 0 && slotIndex < GL_MAX_TEXTURE_2D) {
-                if (texture2D[slotIndex]) return;
-                texture2D[slotIndex] = GL_TRUE;
+                if (glState.texture2D[slotIndex]) return;
+                glState.texture2D[slotIndex] = GL_TRUE;
             }
             break;
         }
     }
     glEnable(cap);
 }
-
 #undef glEnable
 #define glEnable cached_glEnable
 
 static inline void cached_glDisable(GLenum cap) {
     switch (cap) {
         case GL_BLEND:
-            if (!blend) return;
-            blend = GL_FALSE;
+            if (!glState.blend) return;
+            glState.blend = GL_FALSE;
             break;
         case GL_DEPTH_TEST:
-            if (!depthTest) return;
-            depthTest = GL_FALSE;
+            if (!glState.depthTest) return;
+            glState.depthTest = GL_FALSE;
             break;
         case GL_SCISSOR_TEST:
-            if (!scissorTest) return;
-            scissorTest = GL_FALSE;
+            if (!glState.scissorTest) return;
+            glState.scissorTest = GL_FALSE;
             break;
         case GL_TEXTURE_2D: {
-            int slotIndex = (int)activeTextureSlot - GL_TEXTURE0;
+            int slotIndex = (int)glState.activeTextureSlot - GL_TEXTURE0;
             if (slotIndex >= 0 && slotIndex < GL_MAX_TEXTURE_2D) {
-                if (!texture2D[slotIndex]) return;
-                texture2D[slotIndex] = GL_FALSE;
+                if (!glState.texture2D[slotIndex]) return;
+                glState.texture2D[slotIndex] = GL_FALSE;
             }
             break;
         }
     }
     glDisable(cap);
 }
-
 #undef glDisable
 #define glDisable cached_glDisable
 
 static inline GLboolean cached_glIsEnabled(GLenum cap) {
     switch (cap) {
-        case GL_BLEND:
-            return blend;
-        case GL_DEPTH_TEST:
-            return depthTest;
-        case GL_SCISSOR_TEST:
-            return scissorTest;
+        case GL_BLEND:        return glState.blend;
+        case GL_DEPTH_TEST:   return glState.depthTest;
+        case GL_SCISSOR_TEST: return glState.scissorTest;
         case GL_TEXTURE_2D: {
-            int slotIndex = (int)activeTextureSlot - GL_TEXTURE0;
+            int slotIndex = (int)glState.activeTextureSlot - GL_TEXTURE0;
             if (slotIndex >= 0 && slotIndex < GL_MAX_TEXTURE_2D) {
-                return texture2D[slotIndex];
+                return glState.texture2D[slotIndex];
             }
             return glIsEnabled(cap);
         }
@@ -265,7 +296,6 @@ static inline GLboolean cached_glIsEnabled(GLenum cap) {
             return glIsEnabled(cap);
     }
 }
-
 #undef glIsEnabled
 #define glIsEnabled cached_glIsEnabled
 

--- a/src/gl_legacy/gl_legacy_renderer.c
+++ b/src/gl_legacy/gl_legacy_renderer.c
@@ -155,6 +155,8 @@ static void glInit(Renderer* renderer, DataWin* dataWin) {
         abort();
     }
 
+    GLState_init();
+
     // GL 2.0+ has NPOT textures as core; older GL (1.x) may or may not have
     // GL_ARB_texture_non_power_of_two. Only round up to power-of-two on GPUs
     // that actually need it (Intel 82865G etc.).

--- a/src/gl_legacy/gl_legacy_renderer.c
+++ b/src/gl_legacy/gl_legacy_renderer.c
@@ -2,6 +2,7 @@
 #include "matrix_math.h"
 #include "text_utils.h"
 #include "gl_wrappers.h"
+#include "gl_state.h"
 
 
 #ifdef PLATFORM_PS3


### PR DESCRIPTION
Should benefit the OpenGL 2.x/legacy-gl paths more than 3.0+ but here we are. Less pipeline stalls yippee!