### PR TITLE
feat(cli): search for WAD in OS-specific dirs like the official runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ make
 
 If you are using CLion, set the platform in `Settings` > `Build, Execution, Deployment` > `CMake` and add `-DBACKEND=glfw3`
 
-Then run Butterscotch with `./butterscotch` - it will automatically search for `data.win`, `assets/game.unx` or `../Resources/game.ios` relative to the binary, otherwise you can specify a path with `./butterscotch /path/to/data.win`.
+Then run Butterscotch with `./butterscotch` - it will automatically search for `data.win`, `assets/game.unx`, `assets/game.droid` or `../Resources/game.ios` relative to the binary, otherwise you can specify a path with `./butterscotch /path/to/data.win`.
 
 ## CLI parameters
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ make
 
 If you are using CLion, set the platform in `Settings` > `Build, Execution, Deployment` > `CMake` and add `-DBACKEND=glfw3`
 
-Then run Butterscotch with `./butterscotch /path/to/data.win`!
+Then run Butterscotch with `./butterscotch` - it will automatically search for `data.win`, `assets/game.unx` or `../Resources/game.ios` relative to the binary, otherwise you can specify a path with `./butterscotch /path/to/data.win`.
 
 ## CLI parameters
 

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -523,7 +523,7 @@ static void parseCommandLineArgs(CommandLineArgs* args, int argc, char* argv[]) 
     }
 
     if (optind >= argc) {
-        const char* defaultDataWinPaths[3] = {"data.win", "assets/game.unx", "../Resources/game.ios"};
+        const char* defaultDataWinPaths[4] = {"data.win", "assets/game.unx", "assets/game.droid", "../Resources/game.ios"}; // default WAD paths for Windows/Linux/Android/macOS
         static char resolvedPath[2048];
 
         char baseDir[2048] = {0};
@@ -537,7 +537,7 @@ static void parseCommandLineArgs(CommandLineArgs* args, int argc, char* argv[]) 
         } else {
             baseDir[0] = '\0';
         }
-        for (int i = 0; i < 3; i++) {
+        for (int i = 0; i < 4; i++) {
             snprintf(resolvedPath, sizeof(resolvedPath), "%s%s", baseDir, defaultDataWinPaths[i]);
             if (access(resolvedPath, F_OK) == 0) {
                 args->dataWinPath = resolvedPath;

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -523,10 +523,24 @@ static void parseCommandLineArgs(CommandLineArgs* args, int argc, char* argv[]) 
     }
 
     if (optind >= argc) {
-        const char* defaultDataWinPaths[3] = {"data.win", "assets/game.unx", "../Resources/game.ios"}; // default WAD paths for Windows/Linux/macOS
+        const char* defaultDataWinPaths[3] = {"data.win", "assets/game.unx", "../Resources/game.ios"};
+        static char resolvedPath[2048];
+
+        char baseDir[2048] = {0};
+        strncpy(baseDir, argv[0], sizeof(baseDir) - 1);
+        
+        char* lastSlash = strrchr(baseDir, '/');
+        if (!lastSlash) lastSlash = strrchr(baseDir, '\\');
+        
+        if (lastSlash) {
+            *(lastSlash + 1) = '\0';
+        } else {
+            baseDir[0] = '\0';
+        }
         for (int i = 0; i < 3; i++) {
-            if (access(defaultDataWinPaths[i], F_OK) == 0) {
-                args->dataWinPath = defaultDataWinPaths[i];
+            snprintf(resolvedPath, sizeof(resolvedPath), "%s%s", baseDir, defaultDataWinPaths[i]);
+            if (access(resolvedPath, F_OK) == 0) {
+                args->dataWinPath = resolvedPath;
                 break;
             }
         }

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -523,11 +523,20 @@ static void parseCommandLineArgs(CommandLineArgs* args, int argc, char* argv[]) 
     }
 
     if (optind >= argc) {
-        printUsage(argv[0]);
-        exit(1);
+        const char* defaultDataWinPaths[3] = {"data.win", "assets/game.unx", "../Resources/game.ios"}; // default WAD paths for Windows/Linux/macOS
+        for (int i = 0; i < 3; i++) {
+            if (access(defaultDataWinPaths[i], F_OK) == 0) {
+                args->dataWinPath = defaultDataWinPaths[i];
+                break;
+            }
+        }
+        if (args->dataWinPath == nullptr) {
+            printUsage(argv[0]);
+            exit(1);
+        }
+    } else {
+        args->dataWinPath = argv[optind];
     }
-
-    args->dataWinPath = argv[optind];
 
 #ifdef ENABLE_SCREENSHOTS
     if (hmlen(args->screenshotFrames) > 0 && args->screenshotPattern == nullptr) {


### PR DESCRIPTION
For #463. Makes the runner search for `data.win`, `assets/game.unx`, `assets/game.droid` or `../Resources/game.ios` relative to the binary if the user doesn't provide a WAD path. This is overridden when the user *does* provide a WAD path. This effectively allows the CLI target to drop-in replace the official runner executable.