### PR TITLE
fix(vm): Copy struct vars when running instance_create_depth with 5 args

### DIFF
--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -4101,6 +4101,19 @@ static bool variableScopedExists(VMContext* ctx, int32_t id, const char* name, b
     return result;
 }
 
+static Instance* resolveInstanceValue(Runner* runner, RValue value) {
+    if (value.type == RVALUE_STRUCT && value.structInst != nullptr) {
+        return value.structInst;
+    }
+
+    int32_t id = RValue_toInt32(value);
+    if (id >= INSTANCE_ID_BASE) {
+        return hmget(runner->instancesById, id);
+    }
+
+    return nullptr;
+}
+
 static RValue builtin_variable_global_exists(VMContext* ctx, RValue* args, int32_t argCount) {
     if (1 > argCount || args[0].type != RVALUE_STRING) return RValue_makeBool(false);
     return RValue_makeBool(variableScopedExists(ctx, INSTANCE_GLOBAL, args[0].string, false));
@@ -4121,7 +4134,12 @@ static RValue builtin_variable_global_set(VMContext* ctx, RValue* args, int32_t 
 
 static RValue builtin_variable_instance_get(VMContext* ctx, RValue* args, int32_t argCount) {
     if (2 > argCount || args[1].type != RVALUE_STRING) return RValue_makeUndefined();
-    return variableScopedGet(ctx, RValue_toInt32(args[0]), args[1].string, false, "variable_instance_get");
+
+    Instance* inst = resolveInstanceValue(ctx->runner, args[0]);
+    if (inst == nullptr)
+        return RValue_makeUndefined();
+
+    return variableInstanceGetOn(ctx, inst, args[1].string, "variable_instance_get");
 }
 
 static RValue builtin_variable_instance_set(VMContext* ctx, RValue* args, int32_t argCount) {
@@ -8332,19 +8350,10 @@ static RValue builtin_instance_create_layer(VMContext* ctx, RValue* args, int32_
 static void copyBasisStructVars(
     VMContext* ctx,
     Instance* target,
-    RValue basis
+    Instance* basisInst
 ) {
-    if (basis.type != RVALUE_STRUCT) {
-        return;
-    }
-
-    Instance* basisInst = basis.structInst;
-
-    if (basisInst == nullptr) {
-        return;
-    }
-
     if (basisInst->objectIndex != STRUCT_OBJECT_INDEX) {
+        logWarn("VM: copyBasisStructVars: basis instance is not a struct\n");
         return;
     }
 
@@ -8355,20 +8364,7 @@ static void copyBasisStructVars(
             continue;
         }
 
-        int32_t varID = entry->key;
-        RValue* value = &entry->value;
-
-        RValue copiedValue = RValue_makeIndependent(*value);
-
-        RValue* targetSlot =
-            IntRValueHashMap_getOrInsertUndefined(
-                &target->selfVars,
-                varID
-            );
-
-        RValue_free(targetSlot);
-
-        *targetSlot = copiedValue;
+        Instance_setSelfVar(target, entry->key, entry->value);
     }
 }
 
@@ -8388,7 +8384,16 @@ static RValue builtin_instance_create_depth(VMContext* ctx, RValue* args, int32_
     if (inst == nullptr) return RValue_makeReal(INSTANCE_NOONE);
 
     if (argCount >= 5) {
-        copyBasisStructVars(ctx, inst, args[4]);
+        RValue varStruct = args[4];
+        if (varStruct.type != RVALUE_STRUCT) {
+            return RValue_makeReal(INSTANCE_NOONE);
+        }
+
+        Instance* basisInst = varStruct.structInst;
+        if (basisInst == nullptr) {
+            return RValue_makeReal(INSTANCE_NOONE);
+        }
+        copyBasisStructVars(ctx, inst, basisInst);
     }
 
     if (callerInst != nullptr && ctx->creatorVarID >= 0) {

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -8329,20 +8329,68 @@ static RValue builtin_instance_create_layer(VMContext* ctx, RValue* args, int32_
     return RValue_makeReal((GMLReal) inst->instanceId);
 }
 
+static void copyBasisStructVars(
+    VMContext* ctx,
+    Instance* target,
+    RValue basis
+) {
+    if (basis.type != RVALUE_STRUCT) {
+        return;
+    }
+
+    Instance* basisInst = basis.structInst;
+
+    if (basisInst == nullptr) {
+        return;
+    }
+
+    if (basisInst->objectIndex != STRUCT_OBJECT_INDEX) {
+        return;
+    }
+
+    for (uint32_t i = 0; i < basisInst->selfVars.capacity; i++) {
+        IntRValueEntry* entry = &basisInst->selfVars.entries[i];
+
+        if (entry->key == INT_RVALUE_HASHMAP_EMPTY_KEY) {
+            continue;
+        }
+
+        int32_t varID = entry->key;
+        RValue* value = &entry->value;
+
+        RValue copiedValue = RValue_makeIndependent(*value);
+
+        RValue* targetSlot =
+            IntRValueHashMap_getOrInsertUndefined(
+                &target->selfVars,
+                varID
+            );
+
+        RValue_free(targetSlot);
+
+        *targetSlot = copiedValue;
+    }
+}
+
 static RValue builtin_instance_create_depth(VMContext* ctx, RValue* args, int32_t argCount) {
-    if (3 > argCount) return RValue_makeReal(0.0);
+    if (4 > argCount) return RValue_makeReal(0.0);
     Runner* runner = ctx->runner;
     GMLReal x = RValue_toReal(args[0]);
     GMLReal y = RValue_toReal(args[1]);
     int32_t depth = RValue_toInt32(args[2]);
     int32_t objectIndex = RValue_toInt32(args[3]);
     if (0 > objectIndex || runner->dataWin->objt.count <= (uint32_t) objectIndex) {
-        logWarn("VM: instance_create: objectIndex %d out of range\n", objectIndex);
-        return RValue_makeReal(0.0);
+        logWarn("VM: instance_create_depth: objectIndex %d out of range\n", objectIndex);
+        return RValue_makeReal(INSTANCE_NOONE);
     }
     Instance* callerInst = ctx->currentInstance;
     Instance* inst = Runner_createInstanceWithDepth(runner, x, y, objectIndex, depth);
     if (inst == nullptr) return RValue_makeReal(INSTANCE_NOONE);
+
+    if (argCount >= 5) {
+        copyBasisStructVars(ctx, inst, args[4]);
+    }
+
     if (callerInst != nullptr && ctx->creatorVarID >= 0) {
         Instance_setSelfVar(inst, ctx->creatorVarID, RValue_makeReal((GMLReal) callerInst->instanceId));
     }


### PR DESCRIPTION
This is in line with the official HTML5 runner:

```js
function instance_create_depth( _x,_y,_depth,_objind, _basis) 
{
	if (g_pLayerManager.GetTargetRoomObj() != g_RunRoom) return -1;

	if(_depth == undefined)
		_depth = 0;
    _objind = yyGetInt32(_objind);
	
    var o = g_pObjectManager.Get(_objind);
	if (!o)
	{
		yyError("Error: Trying to create an instance using non-existent object type (" + _objind + ")");
		return OBJECT_NOONE;
	}
    var inst =g_RunRoom.GML_AddInstanceDepth(yyGetReal(_x), yyGetReal(_y), yyGetInt32(_depth), _objind);
  
    if(inst!=null)
    {
        inst.PerformEvent(EVENT_PRE_CREATE, 0, inst, inst );
        ShallowCopyVars( inst, _basis );
        inst.PerformEvent(EVENT_CREATE, 0, inst, inst );
	    return MAKE_REF(REFID_INSTANCE, inst.id);
    }

	return OBJECT_NOONE;
};
```

As seen, it does a shallow copy with `_basis`. This was absent in Butterscotch, so instances created using this function would be missing several fields. This caused issues in DELTARUNE Chapter 5 "obj_dialoguer_plat". In its create event, it would run:

```gml
if (!variable_instance_exists(id, "skippable"))
{
    skippable = 1;
}
```

Due to the shallow copy not being implemented, `skippable` would never exist, so skippable was always set to 1. This caused issues in the Draw event, where this code would execute.

```gml
else if (instance_exists(mywriter) && !skippable && mywriter.reachedend)
{
    if (delay >= 0)
    {
        delay--;
    }
}
```

As skippable was always true, this code would never execute. Later on in the Draw event, it checks if delay is -1 (the lowest possible value of delay), and proceeds to the next message if that check returns true. As skippable is always true, delay can never decrement, so the message can never proceed.

This fix ensures that dialogue boxes can progress as intended, and it also fixes a softlock in Seth and Aqua's fight. 