### PR TITLE
Print contents of structs and arrays

### DIFF
--- a/src/gml_array.c
+++ b/src/gml_array.c
@@ -130,7 +130,7 @@ void GMLArray_growTo(GMLArray* arr, int32_t minLength) {
 }
 
 
-char* GMLArray_toString(const GMLArray* arr, DataWin* dataWin) {
+char* GMLArray_toStringFancy(const GMLArray* arr, DataWin* dataWin) {
     if (arr == nullptr)
         return safeStrdup("[]");
 
@@ -175,7 +175,7 @@ char* GMLArray_toString(const GMLArray* arr, DataWin* dataWin) {
 
                 first = false;
 
-                char* valStr = RValue_toString(row->data[c], dataWin);
+                char* valStr = RValue_toStringFancy(row->data[c], dataWin);
                 APPEND_STRING(valStr);
                 free(valStr);
             }
@@ -187,7 +187,7 @@ char* GMLArray_toString(const GMLArray* arr, DataWin* dataWin) {
 
             first = false;
 
-            char* valStr = RValue_toString(arr->modern.data[i], dataWin);
+            char* valStr = RValue_toStringFancy(arr->modern.data[i], dataWin);
             APPEND_STRING(valStr);
             free(valStr);
         }

--- a/src/gml_array.c
+++ b/src/gml_array.c
@@ -137,7 +137,7 @@ char* GMLArray_toStringFancy(const GMLArray* arr, DataWin* dataWin) {
     size_t capacity = 128;
     size_t length = 0;
 
-    char* buf = safeMalloc(capacity);
+    char* buf = (char*)safeMalloc(capacity);
 
     buf[0] = '\0';
 
@@ -147,7 +147,7 @@ char* GMLArray_toStringFancy(const GMLArray* arr, DataWin* dataWin) {
             if (needed > capacity) { \
                 while (capacity < needed) \
                     capacity *= 2; \
-                buf = safeRealloc(buf, capacity); \
+                buf = (char*)safeRealloc(buf, capacity); \
             } \
         } while (0)
 

--- a/src/gml_array.c
+++ b/src/gml_array.c
@@ -171,7 +171,7 @@ char* GMLArray_toString(const GMLArray* arr, DataWin* dataWin) {
 
             for (int c = 0; c < row->length; c++) {
                 if (!first)
-                    APPEND_STRING(", ");
+                    APPEND_STRING(",");
 
                 first = false;
 
@@ -183,7 +183,7 @@ char* GMLArray_toString(const GMLArray* arr, DataWin* dataWin) {
     } else {
         for (int i = 0; i < arr->modern.length; i++) {
             if (!first)
-                APPEND_STRING(", ");
+                APPEND_STRING(",");
 
             first = false;
 

--- a/src/gml_array.c
+++ b/src/gml_array.c
@@ -128,3 +128,75 @@ void GMLArray_growTo(GMLArray* arr, int32_t minLength) {
         arr->modern.length = minLength;
     }
 }
+
+
+char* GMLArray_toString(const GMLArray* arr, DataWin* dataWin) {
+    if (arr == nullptr)
+        return safeStrdup("[]");
+
+    size_t capacity = 128;
+    size_t length = 0;
+
+    char* buf = safeMalloc(capacity);
+
+    buf[0] = '\0';
+
+    #define ENSURE_SPACE(extra) \
+        do { \
+            size_t needed = length + (extra) + 1; \
+            if (needed > capacity) { \
+                while (capacity < needed) \
+                    capacity *= 2; \
+                buf = safeRealloc(buf, capacity); \
+            } \
+        } while (0)
+
+    #define APPEND_STRING(str) \
+        do { \
+            const char* _str = (str); \
+            size_t _len = strlen(_str); \
+            ENSURE_SPACE(_len); \
+            memcpy(buf + length, _str, _len); \
+            length += _len; \
+            buf[length] = '\0'; \
+        } while (0)
+
+    APPEND_STRING("[ ");
+
+    bool first = true;
+
+    if (arr->type == GML_LEGACY_ARRAY) {
+        for (int r = 0; r < arr->legacy.rowCount; r++) {
+            GMLArrayRow* row = &arr->legacy.rows[r];
+
+            for (int c = 0; c < row->length; c++) {
+                if (!first)
+                    APPEND_STRING(", ");
+
+                first = false;
+
+                char* valStr = RValue_toString(row->data[c], dataWin);
+                APPEND_STRING(valStr);
+                free(valStr);
+            }
+        }
+    } else {
+        for (int i = 0; i < arr->modern.length; i++) {
+            if (!first)
+                APPEND_STRING(", ");
+
+            first = false;
+
+            char* valStr = RValue_toString(arr->modern.data[i], dataWin);
+            APPEND_STRING(valStr);
+            free(valStr);
+        }
+    }
+
+    APPEND_STRING(" ]");
+
+    #undef ENSURE_SPACE
+    #undef APPEND_STRING
+
+    return buf;
+}

--- a/src/gml_array.h
+++ b/src/gml_array.h
@@ -157,4 +157,6 @@ static inline void GMLArray_addOnArrayRef(RValue* arrayRef, RValue val) {
     GMLArray_add(arrayRef->array, val);
 }
 
+char* GMLArray_toString(const GMLArray* arr, DataWin* dataWin);
+
 #endif /* _BS_GML_ARRAY_H_ */

--- a/src/instance.c
+++ b/src/instance.c
@@ -230,7 +230,7 @@ char* Instance_toString(Instance* inst, DataWin* dataWin) {
 
         if (name == nullptr) name = "?";
         RValue val = entries[idx].value;
-        char* valStr = RValue_toStringTyped(val);
+        char* valStr = RValue_toString(val, dataWin);
         requiredSize += strlen(name) + strlen(valStr) + (first ? 0 : 2) + 5; // "name : value" + separators
         free(valStr);
         first = false;
@@ -257,7 +257,7 @@ char* Instance_toString(Instance* inst, DataWin* dataWin) {
             if (name == nullptr) name = "?";
 
             RValue val = entries[idx].value;
-            char* valStr = RValue_toStringTyped(val);
+            char* valStr = RValue_toString(val, dataWin);
             if (!first) {
                 pos += snprintf(buf + pos, bufSize - pos, ", ");
             }

--- a/src/instance.c
+++ b/src/instance.c
@@ -205,7 +205,7 @@ void Instance_computeComponentsFromSpeed(Instance* inst) {
     }
 }
 
-char* Instance_toString(Instance* inst, DataWin* dataWin) {
+char* Instance_toStringFancy(Instance* inst, DataWin* dataWin) {
     const IntRValueHashMap* map = &inst->selfVars;
     if (map->capacity == 0) return safeStrdup("{}");
     const IntRValueEntry* entries = map->entries;
@@ -230,7 +230,7 @@ char* Instance_toString(Instance* inst, DataWin* dataWin) {
 
         if (name == nullptr) name = "?";
         RValue val = entries[idx].value;
-        char* valStr = RValue_toString(val, dataWin);
+        char* valStr = RValue_toStringFancy(val, dataWin);
         requiredSize += strlen(name) + strlen(valStr) + (first ? 0 : 2) + 5; // "name : value" + separators
         free(valStr);
         first = false;
@@ -257,7 +257,7 @@ char* Instance_toString(Instance* inst, DataWin* dataWin) {
             if (name == nullptr) name = "?";
 
             RValue val = entries[idx].value;
-            char* valStr = RValue_toString(val, dataWin);
+            char* valStr = RValue_toStringFancy(val, dataWin);
             if (!first) {
                 pos += snprintf(buf + pos, bufSize - pos, ", ");
             }

--- a/src/instance.c
+++ b/src/instance.c
@@ -1,4 +1,5 @@
 #include "instance.h"
+#include "vm.h"
 
 #include <stdlib.h>
 #include "string_compat.h"
@@ -202,4 +203,69 @@ void Instance_computeComponentsFromSpeed(Instance* inst) {
     if (GMLReal_fabs(inst->vspeed - GMLReal_round(inst->vspeed)) < 0.0001) {
         inst->vspeed = (float) GMLReal_round(inst->vspeed);
     }
+}
+
+char* Instance_toString(Instance* inst, DataWin* dataWin) {
+    const IntRValueHashMap* map = &inst->selfVars;
+    if (map->capacity == 0) return safeStrdup("{}");
+    const IntRValueEntry* entries = map->entries;
+    uint32_t mask = map->mask;
+
+    size_t requiredSize = 4; // "{ }\0"
+    bool first = true;
+    for (uint32_t idx = 0; idx <= mask; ++idx) {
+        int32_t slotKey = entries[idx].key;
+        if (slotKey == INT_RVALUE_HASHMAP_EMPTY_KEY) continue;
+
+        const char* name = "?";
+        if (dataWin != nullptr) {
+            repeat(dataWin->vari.variableCount, varIdx) {
+                Variable* var = &dataWin->vari.variables[varIdx];
+                if (var->instanceType == INSTANCE_SELF && var->varID == slotKey) {
+                    name = var->name;
+                    break;
+                }
+            }
+        }
+
+        if (name == nullptr) name = "?";
+        RValue val = entries[idx].value;
+        char* valStr = RValue_toStringTyped(val);
+        requiredSize += strlen(name) + strlen(valStr) + (first ? 0 : 2) + 5; // "name : value" + separators
+        free(valStr);
+        first = false;
+    }
+
+    size_t bufSize = requiredSize > 128 ? requiredSize : 128;
+    char* buf = (char*) safeCalloc(bufSize, sizeof(char));
+    size_t pos = 0;
+    pos += snprintf(buf + pos, bufSize - pos, "{ ");
+    first = true;
+    for (uint32_t idx = 0; idx <= mask; ++idx) {
+        int32_t slotKey = entries[idx].key;
+        if (slotKey != INT_RVALUE_HASHMAP_EMPTY_KEY) {
+            const char* name = "?";
+            if (dataWin != nullptr) {
+                repeat(dataWin->vari.variableCount, varIdx) {
+                    Variable* var = &dataWin->vari.variables[varIdx];
+                    if (var->instanceType == INSTANCE_SELF && var->varID == slotKey) {
+                        name = var->name;
+                        break;
+                    }
+                }
+            }
+            if (name == nullptr) name = "?";
+
+            RValue val = entries[idx].value;
+            char* valStr = RValue_toStringTyped(val);
+            if (!first) {
+                pos += snprintf(buf + pos, bufSize - pos, ", ");
+            }
+            first = false;
+            pos += snprintf(buf + pos, bufSize - pos, "%s : %s", name, valStr);
+            free(valStr);
+        }
+    }
+    pos += snprintf(buf + pos, bufSize - pos, " }");
+    return buf;
 }

--- a/src/instance.h
+++ b/src/instance.h
@@ -119,6 +119,6 @@ void Instance_computeSpeedFromComponents(Instance* inst);
 // Recompute hspeed/vspeed from speed/direction (called when speed or direction is set)
 void Instance_computeComponentsFromSpeed(Instance* inst);
 
-char* Instance_toString(Instance* inst, DataWin* dataWin);
+char* Instance_toStringFancy(Instance* inst, DataWin* dataWin);
 
 #endif /* _BS_INSTANCE_H_ */

--- a/src/instance.h
+++ b/src/instance.h
@@ -119,4 +119,6 @@ void Instance_computeSpeedFromComponents(Instance* inst);
 // Recompute hspeed/vspeed from speed/direction (called when speed or direction is set)
 void Instance_computeComponentsFromSpeed(Instance* inst);
 
+char* Instance_toString(Instance* inst, DataWin* dataWin);
+
 #endif /* _BS_INSTANCE_H_ */

--- a/src/rvalue.h
+++ b/src/rvalue.h
@@ -17,6 +17,7 @@ struct GMLArray;
 typedef struct GMLArray GMLArray;
 void GMLArray_decRef(struct GMLArray* arr);
 void GMLArray_incRef(struct GMLArray* arr);
+char* GMLArray_toString(const GMLArray* arr, DataWin* dataWin);
 
 struct Instance;
 typedef struct Instance Instance;
@@ -349,8 +350,14 @@ static inline char* RValue_toString(RValue val, DataWin* dataWin) {
         case RVALUE_UNDEFINED:
             return safeStrdup("undefined");
         case RVALUE_ARRAY:
-            snprintf(buf, sizeof(buf), "<array:%p>", (void*) val.array);
-            return safeStrdup(buf);
+            {
+                char* arrStr = GMLArray_toString(val.array, dataWin);
+                size_t needed = strlen(arrStr) + 1;
+                char* result = (char*) safeCalloc(needed, sizeof(char));
+                snprintf(result, needed, "%s", arrStr);
+                free(arrStr);
+                return result;
+            }
 #if IS_WAD17_OR_HIGHER_ENABLED
         case RVALUE_METHOD:
             snprintf(buf, sizeof(buf), "<method:%d>", val.method->codeIndex);

--- a/src/rvalue.h
+++ b/src/rvalue.h
@@ -22,6 +22,7 @@ struct Instance;
 typedef struct Instance Instance;
 void Instance_structIncRef(struct Instance* inst);
 void Instance_structDecRef(struct Instance* inst);
+char* Instance_toString(Instance* inst, DataWin* dataWin);
 uint32_t Instance_getInstanceId(struct Instance* inst);
 
 #include "gml_method.h"
@@ -356,8 +357,14 @@ static inline char* RValue_toString(RValue val, DataWin* dataWin) {
             return safeStrdup(buf);
 #endif
         case RVALUE_STRUCT:
-            snprintf(buf, sizeof(buf), "<struct:%u>", val.structInst != nullptr ? Instance_getInstanceId(val.structInst) : 0);
-            return safeStrdup(buf);
+            {
+                char* structStr = Instance_toString(val.structInst, dataWin);
+                size_t needed = strlen(structStr) + 1;
+                char* result = (char*) safeCalloc(needed, sizeof(char));
+                snprintf(result, needed, "%s", structStr);
+                free(structStr);
+                return result;
+            }
         case RVALUE_ASSETREF:
             assetNameFromDataWin = RValue_getAssetName(val, dataWin);
             switch (val.assetRefType) {

--- a/src/rvalue.h
+++ b/src/rvalue.h
@@ -17,13 +17,13 @@ struct GMLArray;
 typedef struct GMLArray GMLArray;
 void GMLArray_decRef(struct GMLArray* arr);
 void GMLArray_incRef(struct GMLArray* arr);
-char* GMLArray_toString(const GMLArray* arr, DataWin* dataWin);
+char* GMLArray_toStringFancy(const GMLArray* arr, DataWin* dataWin);
 
 struct Instance;
 typedef struct Instance Instance;
 void Instance_structIncRef(struct Instance* inst);
 void Instance_structDecRef(struct Instance* inst);
-char* Instance_toString(Instance* inst, DataWin* dataWin);
+char* Instance_toStringFancy(Instance* inst, DataWin* dataWin);
 uint32_t Instance_getInstanceId(struct Instance* inst);
 
 #include "gml_method.h"
@@ -350,28 +350,16 @@ static inline char* RValue_toString(RValue val, DataWin* dataWin) {
         case RVALUE_UNDEFINED:
             return safeStrdup("undefined");
         case RVALUE_ARRAY:
-            {
-                char* arrStr = GMLArray_toString(val.array, dataWin);
-                size_t needed = strlen(arrStr) + 1;
-                char* result = (char*) safeCalloc(needed, sizeof(char));
-                snprintf(result, needed, "%s", arrStr);
-                free(arrStr);
-                return result;
-            }
+            snprintf(buf, sizeof(buf), "<array:%p>", (void*) val.array);
+            return safeStrdup(buf);
 #if IS_WAD17_OR_HIGHER_ENABLED
         case RVALUE_METHOD:
             snprintf(buf, sizeof(buf), "<method:%d>", val.method->codeIndex);
             return safeStrdup(buf);
 #endif
         case RVALUE_STRUCT:
-            {
-                char* structStr = Instance_toString(val.structInst, dataWin);
-                size_t needed = strlen(structStr) + 1;
-                char* result = (char*) safeCalloc(needed, sizeof(char));
-                snprintf(result, needed, "%s", structStr);
-                free(structStr);
-                return result;
-            }
+            snprintf(buf, sizeof(buf), "<struct:%u>", val.structInst != nullptr ? Instance_getInstanceId(val.structInst) : 0);
+            return safeStrdup(buf);
         case RVALUE_ASSETREF:
             assetNameFromDataWin = RValue_getAssetName(val, dataWin);
             switch (val.assetRefType) {
@@ -448,6 +436,24 @@ static inline char* RValue_toStringFancy(RValue val, DataWin* dataWin) {
 
             return valueWithQuotes;
         }
+        case RVALUE_ARRAY:
+            {
+                char* arrStr = GMLArray_toStringFancy(val.array, dataWin);
+                size_t needed = strlen(arrStr) + 1;
+                char* result = (char*) safeCalloc(needed, sizeof(char));
+                snprintf(result, needed, "%s", arrStr);
+                free(arrStr);
+                return result;
+            }
+        case RVALUE_STRUCT:
+            {
+                char* structStr = Instance_toStringFancy(val.structInst, dataWin);
+                size_t needed = strlen(structStr) + 1;
+                char* result = (char*) safeCalloc(needed, sizeof(char));
+                snprintf(result, needed, "%s", structStr);
+                free(structStr);
+                return result;
+            }
         default: {
             return RValue_toString(val, dataWin);
         }

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -1838,7 +1838,7 @@ static RValue builtin_show_debug_message(MAYBE_UNUSED VMContext* ctx, RValue* ar
         return RValue_makeUndefined();
     }
 
-    char* val = RValue_toString(args[0], ctx->runner->dataWin);
+    char* val = RValue_toStringFancy(args[0], ctx->runner->dataWin);
     logInfo("Game: %s\n", val);
     free(val);
 

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -1832,13 +1832,22 @@ void VMBuiltins_setVariable(VMContext* ctx, Instance* inst, int16_t builtinVarId
 
 // ===[ BUILTIN FUNCTION IMPLEMENTATIONS ]===
 
+static inline char* RValue_toDebugMessageString(RValue val, DataWin *datawin) {
+    switch (val.type) {
+        case RVALUE_STRING:
+            return RValue_toString(val, dataWin)
+        default:
+            return RValue_toStringFancy(val, dataWin);
+    }
+}
+
 static RValue builtin_show_debug_message(MAYBE_UNUSED VMContext* ctx, RValue* args, int32_t argCount) {
     if (1 > argCount) {
         logWarn("[show_debug_message] Expected at least 1 argument\n");
         return RValue_makeUndefined();
     }
-
-    char* val = RValue_toStringFancy(args[0], ctx->runner->dataWin);
+    
+    char* val = RValue_toDebugMessageString(args[0], ctx->runner->dataWin);
     logInfo("Game: %s\n", val);
     free(val);
 

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -1832,7 +1832,7 @@ void VMBuiltins_setVariable(VMContext* ctx, Instance* inst, int16_t builtinVarId
 
 // ===[ BUILTIN FUNCTION IMPLEMENTATIONS ]===
 
-static inline char* RValue_toDebugMessageString(RValue val, DataWin *datawin) {
+static inline char* RValue_toDebugMessageString(RValue val, DataWin *dataWin) {
     switch (val.type) {
         case RVALUE_STRING:
             return RValue_toString(val, dataWin);

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -1835,7 +1835,7 @@ void VMBuiltins_setVariable(VMContext* ctx, Instance* inst, int16_t builtinVarId
 static inline char* RValue_toDebugMessageString(RValue val, DataWin *datawin) {
     switch (val.type) {
         case RVALUE_STRING:
-            return RValue_toString(val, dataWin)
+            return RValue_toString(val, dataWin);
         default:
             return RValue_toStringFancy(val, dataWin);
     }


### PR DESCRIPTION
This adds "Instance_toStringFancy" and "GMLArray_toStringFancy" functions, which is added to "RValue_toStringFancy". builtin_show_debug_message has been changed to use RValue_toDebugMessageString, which uses RValue_toString if it's just a string, and RValue_toStringFancy if not. (This is so that show_debug_message("aaa") doesn't output `"aaa"`, but a struct or array containing a string contains the quotes.)

## GML

```gml
var nested = {
	nested: "struct"
};

var arr = [1, 2, 3];

var s = {
	hello: "world",
	value: 4,
	nested: nested,
	arr: arr
};

show_debug_message(s);
```

## Before

```Game: <struct:100002>```

## After

```Game: { arr : [ 1,2,3 ], nested : { nested : "struct" }, hello : "world", value : 4 }```

## Real GameMaker output

```{ value : 4, nested : { nested : "struct" }, arr : [ 1,2,3 ], hello : "world" }```