### PR TITLE
fix(vm): add VM_writeToScriptArgsArrayElement

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -657,6 +657,22 @@ void VM_writeToScriptArgs(VMContext* ctx, int32_t writeIndex, RValue val) {
     ctx->scriptArgs[writeIndex] = independent;
 }
 
+void VM_writeToScriptArgsArrayElement(VMContext* ctx, int32_t writeIndex, int32_t arrayIndex, RValue val) {
+    if (writeIndex < 0) return;
+    if (writeIndex >= ctx->scriptArgCount) {
+        RValue* newScriptArgs = (RValue *)safeCalloc(writeIndex + 1, sizeof(RValue));
+        if (ctx->scriptArgCount > 0) {
+            memcpy(newScriptArgs, ctx->scriptArgs, ctx->scriptArgCount * sizeof(RValue));
+            free(ctx->scriptArgs);
+        }
+        ctx->scriptArgs = newScriptArgs;
+        ctx->scriptArgCount = writeIndex + 1;
+    }
+
+    RValue* slot = &ctx->scriptArgs[writeIndex];
+    VM_arraySetWithCoW(ctx, slot, arrayIndex, val);
+}
+
 static RValue resolveVariableRead(VMContext* ctx, int32_t instanceType, uint32_t varRef) {
     Variable* varDef = resolveVarDef(ctx, varRef);
     ArrayAccess access = popArrayAccess(ctx, varRef);
@@ -992,7 +1008,11 @@ static void resolveVariableWrite(VMContext* ctx, int32_t instanceType, uint32_t 
             logWarn("VM: [%s] INSTANCE_ARG write on unknown variable '%s' (builtinVarId=%d)\n", ctx->currentCodeName, varDef->name, bid);
         }
         if (writeIndex >= 0) {
-            VM_writeToScriptArgs(ctx, writeIndex, val);
+            if (access.isArray) {
+                VM_writeToScriptArgsArrayElement(ctx, writeIndex, access.arrayIndex, val);
+            } else {
+                VM_writeToScriptArgs(ctx, writeIndex, val);
+            }
         }
         RValue_free(&val);
         return;

--- a/src/vm.c
+++ b/src/vm.c
@@ -640,37 +640,33 @@ static bool tryReadInstanceVarOrStatic(VMContext* ctx, Instance* instance, int32
     return false;
 }
 
-void VM_writeToScriptArgs(VMContext* ctx, int32_t writeIndex, RValue val) {
-    RValue independent = RValue_makeIndependent(val);
-    // You CAN write to the builtin argumentX variables even though the function does not "have" it as a function argument
-    // So we'll need to check if we need to resize the scriptArgs manually...
-    if (writeIndex >= ctx->scriptArgCount) {
-        RValue* newScriptArgs = (RValue *)safeCalloc(writeIndex + 1, sizeof(RValue));
-        if (ctx->scriptArgCount > 0) {
-            memcpy(newScriptArgs, ctx->scriptArgs, ctx->scriptArgCount * sizeof(RValue));
-            free(ctx->scriptArgs);
-        }
-        ctx->scriptArgs = newScriptArgs;
-        ctx->scriptArgCount = writeIndex + 1;
+static inline bool VM_ensureScriptArg(VMContext* ctx, int32_t writeIndex) {
+    if (writeIndex < 0) return false;
+    if (writeIndex < ctx->scriptArgCount) return true;
+
+    RValue* newScriptArgs = (RValue *)safeCalloc(writeIndex + 1, sizeof(RValue));
+
+    if (ctx->scriptArgCount > 0) {
+        memcpy(newScriptArgs, ctx->scriptArgs, ctx->scriptArgCount * sizeof(RValue));
+        free(ctx->scriptArgs);
     }
-    RValue_free(&ctx->scriptArgs[writeIndex]); // no-op if we are writing to a resized array that was (originally) out of bounds
+
+    ctx->scriptArgs = newScriptArgs;
+    ctx->scriptArgCount = writeIndex + 1;
+    return true;
+}
+
+void VM_writeToScriptArgs(VMContext* ctx, int32_t writeIndex, RValue val) {
+    if (!VM_ensureScriptArg(ctx, writeIndex)) return;
+
+    RValue independent = RValue_makeIndependent(val);
+    RValue_free(&ctx->scriptArgs[writeIndex]);
     ctx->scriptArgs[writeIndex] = independent;
 }
 
 void VM_writeToScriptArgsArrayElement(VMContext* ctx, int32_t writeIndex, int32_t arrayIndex, RValue val) {
-    if (writeIndex < 0) return;
-    if (writeIndex >= ctx->scriptArgCount) {
-        RValue* newScriptArgs = (RValue *)safeCalloc(writeIndex + 1, sizeof(RValue));
-        if (ctx->scriptArgCount > 0) {
-            memcpy(newScriptArgs, ctx->scriptArgs, ctx->scriptArgCount * sizeof(RValue));
-            free(ctx->scriptArgs);
-        }
-        ctx->scriptArgs = newScriptArgs;
-        ctx->scriptArgCount = writeIndex + 1;
-    }
-
-    RValue* slot = &ctx->scriptArgs[writeIndex];
-    VM_arraySetWithCoW(ctx, slot, arrayIndex, val);
+    if (!VM_ensureScriptArg(ctx, writeIndex)) return;
+    VM_arraySetWithCoW(ctx, &ctx->scriptArgs[writeIndex], arrayIndex, val);
 }
 
 static RValue resolveVariableRead(VMContext* ctx, int32_t instanceType, uint32_t varRef) {

--- a/src/vm.h
+++ b/src/vm.h
@@ -342,6 +342,7 @@ int32_t VM_getOrAllocateVarID(VMContext* ctx, const char* name);
 // Writes to the VMContext's scriptArgs, resizing the underlying array if needed
 // The "val" will be RValue_makeIndependent(val), it won't be freed
 void VM_writeToScriptArgs(VMContext* ctx, int32_t writeIndex, RValue val);
+void VM_writeToScriptArgsArrayElement(VMContext* ctx, int32_t writeIndex, int32_t arrayIndex, RValue val);
 
 static inline const char* VM_getCallerName(VMContext* ctx) {
     return ctx->currentCodeName != nullptr ? ctx->currentCodeName : "<unknown>";

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -1765,6 +1765,8 @@ void VMBuiltins_setVariable(VMContext* ctx, Instance* inst, int16_t builtinVarId
         // argument[N] - array-style write to script arguments
         case BUILTIN_VAR_ARGUMENT:
             if (arrayIndex >= 0) {
+                VM_writeToScriptArgsArrayElement(ctx, arrayIndex, arrayIndex, val);
+            } else {
                 VM_writeToScriptArgs(ctx, arrayIndex, val);
             }
             return;
@@ -1787,7 +1789,11 @@ void VMBuiltins_setVariable(VMContext* ctx, Instance* inst, int16_t builtinVarId
         case BUILTIN_VAR_ARGUMENT14:
         case BUILTIN_VAR_ARGUMENT15: {
             int argNumber = builtinVarId - BUILTIN_VAR_ARGUMENT0;
-            VM_writeToScriptArgs(ctx, argNumber, val);
+            if (arrayIndex >= 0) {
+                VM_writeToScriptArgsArrayElement(ctx, argNumber, arrayIndex, val);
+            } else {
+                VM_writeToScriptArgs(ctx, argNumber, val);
+            }
             return;
         }
 


### PR DESCRIPTION
Fixes an issue where writing to an array element from a script argument would wipe the whole array. The new implementation uses VM_arraySetWithCoW for arrays. I tested the following code:

```gml
function test_array(arg3)
{
    show_debug_message("BEFORE len=" + string(array_length(arg3)));

    arg3[0] = round(arg3[0] * 30);

    show_debug_message("AFTER len=" + string(array_length(arg3)));
    show_debug_message("arg3[0]=" + string(arg3[0]));
    show_debug_message("arg3[1]=" + string(arg3[1]));

    return array_length(arg3);
}

var result = test_array([
    0.05, 0.05, 0.05, 0.1,
    0.1, 0.1, 0.1, 0.5
]);

show_debug_message("RESULT=" + string(result));
```

## Before

```
Game: BEFORE len=8
Game: AFTER len=0
Game: arg3[0]=2
Game: arg3[1]=2
Game: RESULT=0
```

## After

```
Game: BEFORE len=8
Game: AFTER len=8
Game: arg3[0]=2
Game: arg3[1]=0.05
Game: RESULT=8
```

## GameMaker v2026.0.0.23

```
BEFORE len=8
AFTER len=8
arg3[0]=2
arg3[1]=0.05
RESULT=8
```

This fixes a softlock in `room_dw_fcastle_right_wing_floweryscene` where `gml_Object_obj_ch5_DWCR_documents_Step_0` would do

```gml
_animtime = c_animate_complex(asgore_actor, 8439, 1, [0.05, 0.05, 0.05, 0.1, 0.1, 0.1, 0.1, 0.5], "seconds");
c_wait(_animtime - 12);
```

Inside c_animate_complex, `arg3[i]` is written to. Without this PR, writing to `arg3[i]` causes the VM to destroy arg3, meaning when it loops around again, `array_length(arg3)` is 0, and the loop exits early. This causes `_animtime` to equal 2, causing it to run `c_wait(2 - 12)`, which is a negative number, causing a softlock.

```gml
function c_animate_complex(arg0, arg1, arg2, arg3, arg4 = 0)
{
    if (arg4 == "frames")
    {
        arg4 = 0;
    }
    if (arg4 == "seconds")
    {
        arg4 = 1;
    }
    var _frames_to_complete = 0;
    for (var i = 0; i < array_length(arg3); i++)
    {
        if (arg4 == 1)
        {
            arg3[i] = round(arg3[i] * 30);
        }
        _frames_to_complete += arg3[i];
    }
    c_cmd_x("animcomplex", arg0, arg1, arg2, arg3, 0, 0);
    return _frames_to_complete;
}
```