### PR TITLE
Fix order of events in instance_create_depth

### DIFF
--- a/src/runner.c
+++ b/src/runner.c
@@ -2442,7 +2442,7 @@ Instance* Runner_createInstanceWithDepth(Runner* runner, GMLReal x, GMLReal y, i
     if (isObjectDisabled(runner, objectIndex)) return nullptr;
     Instance* inst = createAndInitInstance(runner, runner->nextInstanceId++, objectIndex, x, y);
     inst->depth = depth;
-    dispatchInstanceCreationEvents(runner, inst);
+    Runner_executeEvent(runner, inst, EVENT_PRECREATE, 0);
     return inst;
 }
 

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -8420,6 +8420,9 @@ static RValue builtin_instance_create_depth(VMContext* ctx, RValue* args, int32_
         copyBasisStructVars(ctx, inst, basisInst);
     }
 
+    Runner_executeEvent(runner, inst, EVENT_CREATE, 0);
+    inst->createEventFired = true;
+
     if (callerInst != nullptr && ctx->creatorVarID >= 0) {
         Instance_setSelfVar(inst, ctx->creatorVarID, RValue_makeReal((GMLReal) callerInst->instanceId));
     }


### PR DESCRIPTION
This adjusts instance_create_depth so it runs the create event of the instance after copying the struct, not before. This is in line with the HTML5 runner and the decompiled Windows runner.