### PR TITLE
Clear stale instance references to instance

### DIFF
--- a/src/runner.c
+++ b/src/runner.c
@@ -1402,6 +1402,10 @@ static Instance** takePersistentInstances(Runner* runner) {
             }
 #endif
 
+            // Clear the slot before freeing the instance so any nested destroy/cleanup code cannot
+            // accidentally dereference a stale pointer that remains in runner->instances during room transitions.
+            runner->instances[i] = nullptr;
+
             hmdel(runner->instancesById, inst->instanceId);
             Runner_executeEvent(runner, inst, EVENT_CLEANUP, 0);
             Runner_removeInstanceFromObjectLists(runner, inst);
@@ -2493,6 +2497,33 @@ void Runner_setGameArgs(Runner* runner, char** argv, int32_t argc) {
     {repeat(argc, i) arrput(runner->gameArgs, safeStrdup(argv[i]));}
 }
 
+static void Runner_clearStaleInstanceReferencesToInstance(Runner* runner, Instance* destroyedInst) {
+    if (runner == nullptr || destroyedInst == nullptr) return;
+
+    // A destroyed instance can still be referenced by another instance's per-instance state
+    // as an integer id (e.g. linked-list pointers, owner ids, chain heads, etc.). Rewrite any
+    // stale id equal to the dying instance back to -4.
+    int32_t destroyedInstanceId = destroyedInst->instanceId;
+    int32_t count = (int32_t) arrlen(runner->instances);
+    for (int32_t i = 0; i < count; i++) {
+        Instance* inst = runner->instances[i];
+        if (inst == nullptr || !inst->active || inst->destroyed || inst->objectIndex < 0) continue;
+
+        repeat(inst->selfVars.capacity, slotIndex) {
+            IntRValueEntry* entry = &inst->selfVars.entries[slotIndex];
+            if (entry->key == INT_RVALUE_HASHMAP_EMPTY_KEY) continue;
+
+            if (
+                (entry->value.type == RVALUE_INT32 && entry->value.int32 == destroyedInstanceId) ||
+                (entry->value.type == RVALUE_INT64 && entry->value.int64 == destroyedInstanceId) ||
+                (entry->value.type == RVALUE_REAL && entry->value.real == (GMLReal) destroyedInstanceId)
+            ) {
+                entry->value = RValue_makeInt32(INSTANCE_NOONE);
+            }
+        }
+    }
+}
+
 void Runner_destroyInstance(MAYBE_UNUSED Runner* runner, Instance* inst, bool runDestroyEvent) {
     // We check this to avoid a infinite loop if "inst" is destroyed within a event destroy event
     if (inst->destroyed)
@@ -2504,6 +2535,10 @@ void Runner_destroyInstance(MAYBE_UNUSED Runner* runner, Instance* inst, bool ru
     // A destroyed instance must ALWAYS be not active
     // If a destroyed instance is active, then well, something went VERY wrong
     inst->active = false;
+
+    // Any selfVars that still hold the destroyed instance's id must be invalidated back to
+    // noone (-4) before the instance is fully reclaimed.
+    Runner_clearStaleInstanceReferencesToInstance(runner, inst);
 
 #ifdef ENABLE_VM_TRACING
     GameObject* gameObject = &runner->dataWin->objt.objects[inst->objectIndex];

--- a/src/runner.c
+++ b/src/runner.c
@@ -2503,20 +2503,26 @@ static void Runner_clearStaleInstanceReferencesToInstance(Runner* runner, Instan
     // A destroyed instance can still be referenced by another instance's per-instance state
     // as an integer id (e.g. linked-list pointers, owner ids, chain heads, etc.). Rewrite any
     // stale id equal to the dying instance back to -4.
+
+    // This is probably not very optimal as it loops through every single instance and every single
+    // selfVar slot, but it doesn't happen too often so maybe it should be okay?
+    // Another option would be to keep a reverse lookup table of instance ids to instances that reference them,
+    // but that would be more memory and complexity overhead.
+
     int32_t destroyedInstanceId = destroyedInst->instanceId;
     int32_t count = (int32_t) arrlen(runner->instances);
     for (int32_t i = 0; i < count; i++) {
         Instance* inst = runner->instances[i];
         if (inst == nullptr || !inst->active || inst->destroyed || inst->objectIndex < 0) continue;
-
         repeat(inst->selfVars.capacity, slotIndex) {
             IntRValueEntry* entry = &inst->selfVars.entries[slotIndex];
             if (entry->key == INT_RVALUE_HASHMAP_EMPTY_KEY) continue;
 
+            uint8_t vtype = entry->value.type;
             if (
-                (entry->value.type == RVALUE_INT32 && entry->value.int32 == destroyedInstanceId) ||
-                (entry->value.type == RVALUE_INT64 && entry->value.int64 == destroyedInstanceId) ||
-                (entry->value.type == RVALUE_REAL && entry->value.real == (GMLReal) destroyedInstanceId)
+                (vtype == RVALUE_INT32 && entry->value.int32 == destroyedInstanceId) ||
+                (vtype == RVALUE_INT64 && entry->value.int64 == destroyedInstanceId) ||
+                (vtype == RVALUE_REAL && entry->value.real == (GMLReal) destroyedInstanceId)
             ) {
                 entry->value = RValue_makeInt32(INSTANCE_NOONE);
             }

--- a/src/runner.c
+++ b/src/runner.c
@@ -2521,7 +2521,9 @@ static void Runner_clearStaleInstanceReferencesToInstance(Runner* runner, Instan
             uint8_t vtype = entry->value.type;
             if (
                 (vtype == RVALUE_INT32 && entry->value.int32 == destroyedInstanceId) ||
+#ifndef NO_RVALUE_INT64
                 (vtype == RVALUE_INT64 && entry->value.int64 == destroyedInstanceId) ||
+#endif
                 (vtype == RVALUE_REAL && entry->value.real == (GMLReal) destroyedInstanceId)
             ) {
                 entry->value = RValue_makeInt32(INSTANCE_NOONE);


### PR DESCRIPTION
This PR adds a function in Runner_destroyInstance to also clear any stale references to that instance from another instance. This fixes a crash in DELTARUNE Chapter 5 where `obj_plat_enm_yellow_ufohat` loops through several instances of `gml_Object_obj_plat_bulletred_ring`, and waits until the next item in the list is -4, however it freezes when the bulletred_ring is destroyed and ends up in an infinite loop. With this PR, now the bulletred_ring will remove any references to itself from other instances, ensuring that it _will_ get that -4 value (INSTANCE_NOONE).

This has potential performance impacts as it loops through _every_ single instance and selfVar upon destroying an instance. Another solution could be to keep track of which instance references another instance but that's also more complexity and overhead. Since this doesn't run per-frame I think it should be fine?

As a fun bonus note for this PR: Chapter 5 is now fully playable from start to finish!