### PR TITLE
Comment for gml_Object_obj_bush_leaf_Step_0 in handlePushEnv

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -2378,6 +2378,8 @@ static void handlePushEnv(VMContext* ctx, uint32_t instr, uint32_t instrAddr) {
     }
 
     if (0 > target) {
+        // This is triggered in DELTARUNE Chapter 5 in room_dw_garden_meetflowery. This is not a bug, as
+        // gml_Object_obj_bush_leaf_Step_0 calls scr_depth(-20). scr_depth then uses with(arg0), causing this log.
         logWarn("VM: [%s] PushEnv with negative target %d, this could be a Int64 number that is getting truncated to Int32!\n", ctx->currentCodeName, target);
     } else {
         logWarn("VM: [%s] PushEnv with unhandled target %d\n", ctx->currentCodeName, target);


### PR DESCRIPTION
This warning gets triggered several times during gml_Object_obj_bush_leaf_Step_0, but it's intentional and hardcoded in the game code. I originally thought there might be a bug, so I'm adding this comment in case anyone else sees these warnings and tries to investigate.

```gml
// gml_Object_obj_bush_leaf_Step_0
if (!init)
{
    init = true;
}
scr_depth(-20);
if (sizer < growtime)
{
    sizer++;
}
```

```gml
// gml_GlobalScript_scr_depth
function scr_depth(arg0 = id, arg1 = 0)
{
    with (arg0)
    {
        depth = 100000 - ((y * 10) + (sprite_height * 10) + (arg1 * 10));
    }
}
```