### PR TITLE
Print method as string

### DIFF
--- a/src/gml_method.c
+++ b/src/gml_method.c
@@ -1,7 +1,30 @@
 #include "gml_method.h"
 #include "common.h"
+#include "data_win.h"
 #include "utils.h"
 #include <stdlib.h>
+
+char* GMLMethod_toString(const GMLMethod* method, DataWin* dataWin) {
+    if (method == nullptr) return safeStrdup("<method:null>");
+    if (method->unresolvedName != nullptr && method->unresolvedName[0] != '\0') {
+        return safeStrdup(method->unresolvedName);
+    }
+    if (dataWin != nullptr && method->codeIndex >= 0 && (uint32_t) method->codeIndex < dataWin->func.functionCount) {
+        const char* name = dataWin->func.functions[method->codeIndex].name;
+        if (name != nullptr && name[0] != '\0') {
+            return safeStrdup(name);
+        }
+    }
+    if (method->builtin != nullptr) {
+        return safeStrdup("<builtin>");
+    }
+    if (method->codeIndex >= 0) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "<method:%d>", method->codeIndex);
+        return safeStrdup(buf);
+    }
+    return safeStrdup("<method>");
+}
 
 GMLMethod* GMLMethod_create(int32_t codeIndex, int32_t boundInstanceId) {
     GMLMethod* m = (GMLMethod *)safeCalloc(1, sizeof(GMLMethod));

--- a/src/gml_method.h
+++ b/src/gml_method.h
@@ -9,6 +9,7 @@ typedef struct VMContext VMContext;
 #endif
 
 typedef struct RValue RValue;
+struct DataWin;
 
 #ifndef BUILTINFUNC_DEFINED
 #define BUILTINFUNC_DEFINED
@@ -29,6 +30,7 @@ typedef struct GMLMethod {
 GMLMethod* GMLMethod_create(int32_t codeIndex, int32_t boundInstanceId);
 GMLMethod* GMLMethod_createBuiltin(BuiltinFunc builtin, int32_t boundInstanceId);
 GMLMethod* GMLMethod_createUnresolved(const char* name, int32_t boundInstanceId);
+char* GMLMethod_toString(const GMLMethod* method, struct DataWin* dataWin);
 void GMLMethod_incRef(GMLMethod* m);
 // Decrement refCount. If it reaches 0, frees the struct. Safe on nullptr.
 void GMLMethod_decRef(GMLMethod* m);

--- a/src/rvalue.h
+++ b/src/rvalue.h
@@ -454,6 +454,17 @@ static inline char* RValue_toStringFancy(RValue val, DataWin* dataWin) {
                 free(structStr);
                 return result;
             }
+#if IS_WAD17_OR_HIGHER_ENABLED
+        case RVALUE_METHOD:
+        {
+            char* methodStr = GMLMethod_toString(val.method, dataWin);
+            size_t needed = strlen(methodStr) + 1;
+            char* result = (char*) safeCalloc(needed, sizeof(char));
+            snprintf(result, needed, "%s", methodStr);
+            free(methodStr);
+            return result;
+        }
+#endif
         default: {
             return RValue_toString(val, dataWin);
         }


### PR DESCRIPTION
Adds GMLMethod_toString to RValue_toStringFancy.

Before:  `<method:1>`
After: `gml_Script____struct___0@gml_Object_Object1_Create_0`