### PR TITLE
Add game speed override and builtin_game_set_speed

### DIFF
--- a/src/loop.c
+++ b/src/loop.c
@@ -1322,7 +1322,7 @@ int loop(CommandLineArgs args, const char *argv0) {
                     logInfo("Memory use right now: %zu bytes (%.1f MB)\n", bytes_used, bytes_used / 1024.0f / 1024.0f);
             }
 
-            // Limit frame rate to the active runtime speed; prefer the explicit override before room/default fallback.
+            // Limit frame rate to room speed (skip in headless mode for max speed!!)
             double effectiveGameSpeed = Runner_getEffectiveGameSpeed(runner);
             if (!args.headless && effectiveGameSpeed > 0.0) {
                 bool fastForwardTabNow = RunnerKeyboard_checkPressed(runner->keyboard, VK_TAB);

--- a/src/loop.c
+++ b/src/loop.c
@@ -1322,8 +1322,9 @@ int loop(CommandLineArgs args, const char *argv0) {
                     logInfo("Memory use right now: %zu bytes (%.1f MB)\n", bytes_used, bytes_used / 1024.0f / 1024.0f);
             }
 
-            // Limit frame rate to room speed (skip in headless mode for max speed!!)
-            if (!args.headless && runner->currentRoom->speed > 0) {
+            // Limit frame rate to the active runtime speed; prefer the explicit override before room/default fallback.
+            double effectiveGameSpeed = Runner_getEffectiveGameSpeed(runner);
+            if (!args.headless && effectiveGameSpeed > 0.0) {
                 bool fastForwardTabNow = RunnerKeyboard_checkPressed(runner->keyboard, VK_TAB);
                 if (args.fastForwardSpeed > 0.0 && fastForwardTabNow && !fastForwardTabPrev) {
                     fastForwardActive = !fastForwardActive;
@@ -1331,7 +1332,7 @@ int loop(CommandLineArgs args, const char *argv0) {
                 }
                 fastForwardTabPrev = fastForwardTabNow;
                 double effectiveSpeed = (args.fastForwardSpeed > 0.0 && fastForwardActive) ? args.fastForwardSpeed : args.speedMultiplier;
-                uint64_t targetFrameTime = 1000000000 / (runner->currentRoom->speed * effectiveSpeed);
+                uint64_t targetFrameTime = 1000000000 / (effectiveGameSpeed * effectiveSpeed);
                 uint64_t nextFrameTime = lastFrameTime + targetFrameTime;
                 platformSleepUntil(nextFrameTime);
             }

--- a/src/runner.c
+++ b/src/runner.c
@@ -2346,6 +2346,7 @@ Runner* Runner_create(DataWin* dataWin, VMContext* vm, Renderer* renderer, FileS
     runner->fileSystem = fileSystem;
     runner->audioSystem = audioSystem;
     runner->frameCount = 0;
+    runner->gameSpeedOverride = 0.0;
     double initialFps = (double)dataWin->gen8.gms2FPS;
     runner->fps = initialFps;
     runner->fpsReal = initialFps;

--- a/src/runner.c
+++ b/src/runner.c
@@ -2132,6 +2132,7 @@ void Runner_reset(Runner* runner) {
     runner->lives = -1.0;
     runner->health = 0.0;
     runner->gameStartFired = false;
+    runner->gameSpeedOverride = 0.0;
     runner->currentRoomIndex = -1;
     runner->currentRoomOrderPosition = -1;
     runner->nextInstanceId = runner->dataWin->gen8.lastObj + 1;

--- a/src/runner.h
+++ b/src/runner.h
@@ -676,6 +676,8 @@ struct Runner {
     int32_t forcedDepth;
     // The time between the last frame and the current frame, stored in microseconds.
     GMLReal deltaTime;
+    // Runtime override for the active game speed. 0 means "unset" and the loop falls back to the room/default FPS.
+    GMLReal gameSpeedOverride;
     // Current frame rate (capped at room speed)
     double fps;                   // last measured frames-per-second value returned to GML
     uint64_t fpsWindowStartNanos;  // nowNanos() at the start of the measurement window
@@ -887,6 +889,14 @@ static inline void Runner_setActiveState(Runner* runner, Instance* instance, boo
 #endif
 
     instance->active = active;
+}
+
+static inline GMLReal Runner_getEffectiveGameSpeed(Runner* runner) {
+    if (runner == nullptr) return 0.0;
+    if (runner->gameSpeedOverride > 0.0) return runner->gameSpeedOverride;
+    if (runner->currentRoom != nullptr && runner->currentRoom->speed > 0) return (GMLReal) runner->currentRoom->speed;
+    if (runner->dataWin != nullptr && runner->dataWin->gen8.gms2FPS > 0.0f) return (GMLReal) runner->dataWin->gen8.gms2FPS;
+    return 30.0;
 }
 
 #endif /* _BS_RUNNER_H_ */

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -1757,8 +1757,6 @@ void VMBuiltins_setVariable(VMContext* ctx, Instance* inst, int16_t builtinVarId
 
             Room* room = resolveRoomForBuiltinAccess(runner);
             if (room != nullptr) room->speed = (uint32_t) RValue_toInt32(val);
-            // Keep pre-room fallback reads consistent if scripts touch room_speed before room init.
-            if (runner->currentRoom == nullptr) runner->dataWin->gen8.gms2FPS = (float) speedValue;
             return;
         }
 
@@ -3320,7 +3318,7 @@ static RValue builtin_game_set_speed(VMContext* ctx, MAYBE_UNUSED RValue* args, 
 
     Room* room = ctx->runner->currentRoom;
     if (room != nullptr) room->speed = (uint32_t) fps;
-    else ctx->runner->dataWin->gen8.gms2FPS = (float) fps;
+    ctx->runner->dataWin->gen8.gms2FPS = (float) fps;
 
     return RValue_makeUndefined();
 }

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -915,13 +915,7 @@ RValue VMBuiltins_getVariable(VMContext* ctx, Instance* inst, int16_t builtinVar
         case BUILTIN_VAR_ROOM_LAST:
             return RValue_makeReal((GMLReal) runner->dataWin->gen8.roomOrder[runner->dataWin->gen8.roomOrderCount - 1]);
         case BUILTIN_VAR_ROOM_SPEED:
-            if (runner->currentRoom == nullptr) {
-                Room* room = resolveRoomForBuiltinAccess(runner);
-                if (room != nullptr) return RValue_makeReal((GMLReal) room->speed);
-                return RValue_makeReal((GMLReal) runner->dataWin->gen8.gms2FPS);
-            }
-
-            return RValue_makeReal((GMLReal) runner->currentRoom->speed);
+            return RValue_makeReal((GMLReal) Runner_getEffectiveGameSpeed(runner));
         case BUILTIN_VAR_ROOM_WIDTH:
             if (runner->currentRoom == nullptr)
                 return RValue_makeReal((GMLReal) -1.0);
@@ -1758,10 +1752,13 @@ void VMBuiltins_setVariable(VMContext* ctx, Instance* inst, int16_t builtinVarId
             return;
         }
         case BUILTIN_VAR_ROOM_SPEED: {
+            double speedValue = (double) RValue_toReal(val);
+            runner->gameSpeedOverride = speedValue;
+
             Room* room = resolveRoomForBuiltinAccess(runner);
             if (room != nullptr) room->speed = (uint32_t) RValue_toInt32(val);
             // Keep pre-room fallback reads consistent if scripts touch room_speed before room init.
-            if (runner->currentRoom == nullptr) runner->dataWin->gen8.gms2FPS = (float) RValue_toReal(val);
+            if (runner->currentRoom == nullptr) runner->dataWin->gen8.gms2FPS = (float) speedValue;
             return;
         }
 
@@ -3306,10 +3303,26 @@ static RValue builtin_randomize(VMContext* ctx, MAYBE_UNUSED RValue* args, MAYBE
 static RValue builtin_game_get_speed(VMContext* ctx, MAYBE_UNUSED RValue* args, MAYBE_UNUSED int32_t argCount) {
     if (1 > argCount) return RValue_makeUndefined();
     int32_t type = RValue_toInt32(args[0]);
-    GMLReal fps = (GMLReal) ctx->runner->currentRoom->speed;
+    GMLReal fps = Runner_getEffectiveGameSpeed(ctx->runner);
     // gamespeed_fps = 0, gamespeed_microseconds = 1
     if (type == 0) return RValue_makeReal(fps);
-    return RValue_makeReal((GMLReal) 1000000.0 / fps);
+    return RValue_makeReal(fps > 0.0 ? (GMLReal) (1000000.0 / fps) : 0.0);
+}
+
+static RValue builtin_game_set_speed(VMContext* ctx, MAYBE_UNUSED RValue* args, MAYBE_UNUSED int32_t argCount) {
+    if (2 > argCount) return RValue_makeUndefined();
+
+    int32_t type = RValue_toInt32(args[0]);
+    GMLReal speedValue = RValue_toReal(args[1]);
+    GMLReal fps = (type == 0) ? speedValue : (speedValue > 0.0 ? (GMLReal) (1000000.0 / speedValue) : 0.0);
+
+    ctx->runner->gameSpeedOverride = fps;
+
+    Room* room = ctx->runner->currentRoom;
+    if (room != nullptr) room->speed = (uint32_t) fps;
+    else ctx->runner->dataWin->gen8.gms2FPS = (float) fps;
+
+    return RValue_makeUndefined();
 }
 
 static RValue builtin_room_exists(VMContext* ctx, MAYBE_UNUSED RValue* args, MAYBE_UNUSED int32_t argCount) {
@@ -19229,6 +19242,7 @@ void VMBuiltins_registerAll(VMContext* ctx) {
 
     // Room
     VM_registerBuiltin(ctx, "game_get_speed", builtin_game_get_speed);
+    VM_registerBuiltin(ctx, "game_set_speed", builtin_game_set_speed);
     VM_registerBuiltin(ctx, "room_exists", builtin_room_exists);
     VM_registerBuiltin(ctx, "room_get_name", builtin_room_get_name);
     VM_registerBuiltin(ctx, "room_get_info", builtin_room_get_info);


### PR DESCRIPTION
I tried to use the [Deltarune 60FPS mod](https://gamebanana.com/mods/688311) but it would make the game run at half speed in Butterscotch. While the room speed was set to 60 in the mod, the gen8.gms2fps was set to 30. By adding the game speed override and a single function to determine game speed (Runner_getEffectiveGameSpeed), the 60FPS mod runs perfectly. I tried without the 60FPS mod and it all seemed fine too.