### PR TITLE
fix(loop): macOS default path for game_change

### DIFF
--- a/src/loop.c
+++ b/src/loop.c
@@ -303,6 +303,32 @@ char** extractRunnerArguments(char* rawArguments) {
     return array;
 }
 
+static char* buildGameChangeTargetPath(const char* currentDataWinPath, const char* workingDirectory, const char* dataWinFilename) {
+    if (dataWinFilename == nullptr || dataWinFilename[0] == '\0') {
+        return nullptr;
+    }
+
+    char* parentDir = safeStrdup(currentDataWinPath);
+    bsGetDirname(parentDir);
+
+    const char* normalizedWorkingDir = workingDirectory;
+    while (*normalizedWorkingDir == '/' || *normalizedWorkingDir == '\\') {
+        normalizedWorkingDir++;
+    }
+
+    bool needParentSeparator = parentDir[0] != '\0' && parentDir[strlen(parentDir) - 1] != '/' && parentDir[strlen(parentDir) - 1] != '\\';
+    size_t newPathLen = strlen(parentDir) + (needParentSeparator ? 1 : 0) + strlen(normalizedWorkingDir) + 1 + strlen(dataWinFilename) + 1;
+    char* newPath = (char *)safeMalloc(newPathLen);
+    if (normalizedWorkingDir[0] == '\0') {
+        snprintf(newPath, newPathLen, "%s%s%s", parentDir, needParentSeparator ? "/" : "", dataWinFilename);
+    } else {
+        snprintf(newPath, newPathLen, "%s%s%s/%s", parentDir, needParentSeparator ? "/" : "", normalizedWorkingDir, dataWinFilename);
+    }
+
+    free(parentDir);
+    return newPath;
+}
+
 // ===[ SCREENSHOT ]===
 // Reads the contents of an FBO (use 0 for the default framebuffer) into a PNG file.
 // If forceOpaque is true, the alpha channel is overwritten with 255, fixing any clobbering done by blending modes.
@@ -1428,6 +1454,14 @@ int loop(CommandLineArgs args, const char *argv0) {
                 }
             }
 
+            bool macosGameChange = (args.osType == OS_MACOSX);
+            // For some reason in the official runner, this value is just hardcoded to be game.ios.
+            // I think this is stupid so I'm only including it as a fallback, since the documentation
+            // says that this requires a "-game <file>". Oh well.
+            if (macosGameChange && dataWinFilename == nullptr) {
+                dataWinFilename = safeStrdup("game.ios");
+            }
+
             if (dataWinFilename == nullptr) {
                 logError("Runner: Launch parameters '%s' did not contain a '-game <file>' entry! Shutting down...\n", nextLaunchParameters);
                 free(nextWorkingDirectory);
@@ -1446,17 +1480,23 @@ int loop(CommandLineArgs args, const char *argv0) {
                 return 1;
             }
 
-            // Get the parent directory of the main data.win file
-            char* parentDir = safeStrdup(currentDataWinPath);
-            bsGetDirname(parentDir);
+            char* newPath = buildGameChangeTargetPath(currentDataWinPath, nextWorkingDirectory, dataWinFilename);
+            if (newPath == nullptr) {
+                logError("Runner: Failed to build target path for game_change! Shutting down...\n");
+                free(nextWorkingDirectory);
+                free(nextLaunchParameters);
+                free(currentDataWinPath);
+                repeat(arrlen(newArguments), i) {
+                    free(newArguments[i]);
+                }
+                arrfree(newArguments);
+                repeat(arrlen(currentGameArgs), i) {
+                    free(currentGameArgs[i]);
+                }
+                arrfree(currentGameArgs);
+                return 1;
+            }
 
-            // The pendingWorkingDirectory contains a slash at the beginning of it (example: /chapter3)
-            // The parentDir does NOT have a trailing slash, so we don't need to bother with it
-            size_t newPathLen = strlen(parentDir) + strlen(nextWorkingDirectory) + 1 + strlen(dataWinFilename) + 1;
-            char* newPath = (char *)safeMalloc(newPathLen);
-            snprintf(newPath, newPathLen, "%s%s/%s", parentDir, nextWorkingDirectory, dataWinFilename);
-
-            free(parentDir);
             free(currentDataWinPath);
             currentDataWinPath = newPath;
             args.dataWinPath = currentDataWinPath;
@@ -1468,13 +1508,21 @@ int loop(CommandLineArgs args, const char *argv0) {
                 arrdel(currentGameArgs, 1);
             }
 
-            repeat(arrlen(newArguments), i) {
-                arrput(currentGameArgs, newArguments[i]);
+            if (macosGameChange) {
+                arrput(currentGameArgs, safeStrdup("-game"));
+                arrput(currentGameArgs, safeStrdup(currentDataWinPath));
+            } else {
+                repeat(arrlen(newArguments), i) {
+                    arrput(currentGameArgs, safeStrdup(newArguments[i]));
+                }
             }
 
             free(dataWinFilename);
             free(nextWorkingDirectory);
             free(nextLaunchParameters);
+            repeat(arrlen(newArguments), i) {
+                free(newArguments[i]);
+            }
             arrfree(newArguments);
         }
     }

--- a/src/loop.c
+++ b/src/loop.c
@@ -1489,8 +1489,8 @@ int loop(CommandLineArgs args, const char *argv0) {
                     free(newArguments[i]);
                 }
                 arrfree(newArguments);
-                repeat(arrlen(currentGameArgs), i) {
-                    free(currentGameArgs[i]);
+                repeat(arrlen(currentGameArgs), j) {
+                    free(currentGameArgs[j]);
                 }
                 arrfree(currentGameArgs);
                 return 1;

--- a/src/loop.c
+++ b/src/loop.c
@@ -1434,13 +1434,13 @@ int loop(CommandLineArgs args, const char *argv0) {
 
         // game_change was called, so we need to restart the runner with the new data.win and launch parameters
         bool macosGameChange = (args.osType == OS_MACOSX);
+        char* dataWinFilename = nullptr;
 
         if (nextWorkingDirectory != nullptr && nextLaunchParameters != nullptr) {
             char** newArguments = nullptr;
             newArguments = extractRunnerArguments(nextLaunchParameters);
 
             // Extract the data.win filename from "-game <file>" inside the new launch parameters
-            char* dataWinFilename = nullptr;
             if (!macosGameChange) {
                 // After extraction, we now need to figure out where is the "-game" argument
                 size_t length = arrlen(newArguments);

--- a/src/loop.c
+++ b/src/loop.c
@@ -1433,13 +1433,15 @@ int loop(CommandLineArgs args, const char *argv0) {
         }
 
         // game_change was called, so we need to restart the runner with the new data.win and launch parameters
+        bool macosGameChange = (args.osType == OS_MACOSX);
+
         if (nextWorkingDirectory != nullptr && nextLaunchParameters != nullptr) {
             char** newArguments = nullptr;
             newArguments = extractRunnerArguments(nextLaunchParameters);
 
             // Extract the data.win filename from "-game <file>" inside the new launch parameters
             char* dataWinFilename = nullptr;
-            {
+            if (!macosGameChange) {
                 // After extraction, we now need to figure out where is the "-game" argument
                 size_t length = arrlen(newArguments);
                 repeat(length, i) {
@@ -1454,11 +1456,8 @@ int loop(CommandLineArgs args, const char *argv0) {
                 }
             }
 
-            bool macosGameChange = (args.osType == OS_MACOSX);
             // For some reason in the official runner, this value is just hardcoded to be game.ios.
-            // I think this is stupid so I'm only including it as a fallback, since the documentation
-            // says that this requires a "-game <file>". Oh well.
-            if (macosGameChange && dataWinFilename == nullptr) {
+            if (macosGameChange) {
                 dataWinFilename = safeStrdup("game.ios");
             }
 


### PR DESCRIPTION
For some reason, GameMaker have decided that game_change doesn't require a `-game` path for macOS, and it just uses a default filename of game.ios in the new directory. This is shown in DELTARUNE:

```gml
launch_game = function(arg0)
{
    audio_stop_all();
    var chapstring = string(_target_chapter);
    var parameters = get_chapter_switch_parameters();
    if (scr_is_switch_os())
    {
        game_change("rom:/chapter" + chapstring + "_switch/", parameters);
    }
    else
    {
        switch (os_type)
        {
            case os_windows:
                game_change("/chapter" + chapstring + "_windows", "-game data.win" + parameters);
                break;
            case os_ps4:
                game_change("", "-game /app0/games/chapter" + chapstring + "_ps4/game.win" + parameters);
                break;
            case os_ps5:
                game_change("", "-game /app0/games/chapter" + chapstring + "_ps5/game.win" + parameters);
                break;
            case os_macosx:
                game_change("chapter" + chapstring + "_mac", parameters);
                break;
        }
    }
};

function get_chapter_switch_parameters()
{
    var launch_data = new launch_parameters();
    if (scr_is_switch_os() && variable_global_exists("switchlogin"))
    {
        launch_data.switch_id = global.switchlogin;
    }
    var parameters = [];
    parameters[0] = "launcher";
    parameters[1] = "switch_" + string(launch_data.switch_id);
    parameters[2] = "returning_" + string(launch_data.returning);
    var param_formatted = "";
    for (var i = 0; i < array_length(parameters); i++)
    {
        param_formatted += (" " + string(parameters[i]));
    }
    return param_formatted;
}
```

And also a decompile of `File_Execute` (the function which `GameChange` calls in the original runner), shows this: `_snprintf(local_838,0x800,s_%s%s/game.ios_1006e7e0f,uVar6,param_3);`.